### PR TITLE
Add site update notification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing Guidelines
 
-Thank you for your interest in contributing to Klaytn Docs. As an open source project, Klaytn Docs is always open to the developer community and we welcome your contribution. Please read the guideline below and follow it in all interactions with the project.
+Thank you for your interest in contributing to Kaia Docs. As an open source project, Kaia Docs is always open to the developer community and we welcome your contribution. Please read the guideline below and follow it in all interactions with the project.
 
-## How to Contribute on Klaytn Docs
+## How to Contribute on Kaia Docs
 
 1. Read this [contributing document](./CONTRIBUTING.md).
 2. Sign [Contributor Licensing Agreement (CLA)](#contributor-license-agreement-cla).
@@ -12,7 +12,7 @@ Thank you for your interest in contributing to Klaytn Docs. As an open source pr
 6. Make a Pull Request (PR): Ensure your proposed changes are accurate, well-documented, and linked to the corresponding issue. Submit a PR against the `main` branch and wait for code review and approval.
 7. Address review feedback: The reviewer may request additional commits or changes. Be responsive and address their feedback to ensure your contribution aligns with the project's standards.
 8. PR merge and branch deletion: Once approved, the project moderator will merge your PR into the main branch. You can then safely delete your working branch.
-9. Content update: The Klaytn Docs website (https://docs.klaytn.foundation/) will be updated with your merged contribution.
+9. Content update: The Kaia Docs website (https://docs.kaia.io/) will be updated with your merged contribution.
 
 ## Types of Contribution
 
@@ -24,34 +24,34 @@ There are various ways to contribute and participate. Please read the guidelines
 
 ### Issues and Typos
 
-If you could identify issues and typos in Klaytn docs, before submitting an issue, please invest some extra time to figure out that:
+If you could identify issues and typos in Kaia docs, before submitting an issue, please invest some extra time to figure out that:
 
 - The issue is not a duplicate issue.
-- The issue has not been covered in the latest release of Klaytn Docs.
-- The issue covers minor typos or errors on the existing content of Klaytn Docs.
+- The issue has not been covered in the latest release of Kaia Docs.
+- The issue covers minor typos or errors on the existing content of Kaia Docs.
 Please do not use the issue tracker for personal support requests. Use developers@klaytn.foundation for the personal support requests.
 
-After confirming your report meets the above criteria, [submit the issue](https://github.com/klaytn/klaytn-docs/issues). Please use [labels](#usage-of-labels) to specify your issue as `issues-and-typos`.
+After confirming your report meets the above criteria, [submit the issue](https://github.com/kaiachain/kaia-docs/issues). Please use [labels](#usage-of-labels) to specify your issue as `issues-and-typos`.
 
 ### Content Contribution
 
-If you would recommend major content change in Klaytn docs, before submitting an issue, please invest some extra time to figure out that:
+If you would recommend major content change in Kaia docs, before submitting an issue, please invest some extra time to figure out that:
 
 - The issue is not a duplicate issue.
-- The issue has not been covered in the latest release of Klaytn Docs.
-- The issue covers major content change (e.g. Adding/removing paragraph and chapter in Klaytn Docs, adding/removing graphical explanation, etc.) on the existing content of Klaytn Docs.
+- The issue has not been covered in the latest release of Kaia Docs.
+- The issue covers major content change (e.g. Adding/removing paragraph and chapter in Kaia Docs, adding/removing graphical explanation, etc.) on the existing content of Kaia Docs.
 Please do not use the issue tracker for personal support requests. Use developers@klaytn.foundation for the personal support requests.
 
-After confirming your report meets the above criteria, [submit the issue](https://github.com/klaytn/klaytn-docs/issues). Please use [labels](#usage-of-labels) to specify your issue as `content-contribution`.
+After confirming your report meets the above criteria, [submit the issue](https://github.com/kaiachain/kaia-docs/issues). Please use [labels](#usage-of-labels) to specify your issue as `content-contribution`.
 
 ### Content Translation
 
-If you are fluent in a language other than English and want to contribute translations or improve the localized documentation, [submit an issue](https://github.com/klaytn/klaytn-docs/issues). Please use [labels](#usage-of-labels) to specify your issue as `content-translation`.
+If you are fluent in a language other than English and want to contribute translations or improve the localized documentation, [submit an issue](https://github.com/kaiachain/kaia-docs/issues). Please use [labels](#usage-of-labels) to specify your issue as `content-translation`.
 
 You need to use the [Crowdin](https://crowdin.com/project/klaytn-docs) platform to contribute translations. For more information, see the [Internationalization](https://docs.klaytn.foundation/docs/misc/internationalization/) page.
 
 > [!IMPORTANT]  
-> For content translation, avoid using a pull request to submit changes by modifying the files under the [i18n](https://github.com/klaytn/klaytn-docs/tree/main/i18n) directory directly. </br> </br> Unlike other types of contribution, the translations are managed by Crowdin localization management platform. If a translation is submitted and has been approved in Crowdin, an automated PR will be made to Klaytn docs repo. Once the PR is approved and merged by the project moderators, the localized Klaytn docs will be updated with the suggested changes (merged content).
+> For content translation, avoid using a pull request to submit changes by modifying the files under the [i18n](https://github.com/klaytn/klaytn-docs/tree/main/i18n) directory directly. </br> </br> Unlike other types of contribution, the translations are managed by Crowdin localization management platform. If a translation is submitted and has been approved in Crowdin, an automated PR will be made to Kaia docs repo. Once the PR is approved and merged by the project moderators, the localized Kaia docs will be updated with the suggested changes (merged content).
 
 ## Usage of Labels
 
@@ -75,12 +75,12 @@ Status of closed issues:
 
 - closed/fixed: A fix for the issue was provided.
 - closed/duplicate: The issue is also reported in a different issue and is being managed there.
-- closed/invalid: The issue is not applicable to the Klaytn Docs.
+- closed/invalid: The issue is not applicable to the Kaia Docs.
 - closed/reject: The issue is rejected after review.
 
 ## Additional Contribution Guidelines
 
-Here are some additional guidelines to follow when contributing to Klaytn Docs:
+Here are some additional guidelines to follow when contributing to Kaia Docs:
 
 ### Commit Messages
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
-# Klaytn Docs
+# Kaia Docs
 
-Welcome to the Klaytn documentation repository! This repo contains the source files for the official Klaytn documentation available at https://docs.klaytn.foundation.
+Welcome to the Kaia documentation repository! This repo contains the source files for the official Kaia documentation available at https://docs.kaia.io.
 
-> [!IMPORTANT]  
-> Attention content contributors! Klaytn docs has shifted platforms, migrating from Gitbook to **Docusaurus**. For key information about this transition and its impact on your contributions, please refer to [the Klaytn docs 2.0 announcement](https://klaytn.foundation/announcing-klaytn-docs-2-0-streamlined-searchable-and-community-powered/).
-
+<!---
 ## Contributing
 
-We welcome contributions to help us improve and expand the Klaytn documentation. There are a few ways you can contribute:
+We welcome contributions to help us improve and expand the Kaia documentation. There are a few ways you can contribute:
 
 ### Contributing to Documentation
 
@@ -22,7 +20,7 @@ Before submitting PRs, make sure to:
 
 ### Contributing Translations
 
-Klaytn docs is available in the following languages:
+Kaia docs is available in the following languages:
 
 - English
 - 한국어
@@ -33,15 +31,16 @@ If you are fluent in a language other than English and want to contribute transl
 Some key points:
 
 - Create an issue with the `content-translation` label.
-- Join the translator team on the [Klaytn-Docs Crowdin project](https://crowdin.com/project/klaytn-docs).
+- Join the translator team on the [Kaia-Docs Crowdin project](https://crowdin.com/project/klaytn-docs).
 - Select the language you want to contribute to.
 - Choose the files to translate or vote on translations.
-- Ensure your word choices conform to the Klaytn Terminologies.
+- Ensure your word choices conform to the Kaia Terminologies.
 - Be respectful and follow the translation Code of Conduct.
 
 Translation suggestions will be reviewed by the maintainers and made available on the localized doc sites when approved and merged.
 
-## Developing Klaytn Docs
+-->
+## Developing Kaia Docs
 
 This website is built using Docusaurus v3.
 

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,4 +1,4 @@
-project_id: '639480'
+project_id: '684038'
 api_token_env: CROWDIN_PERSONAL_TOKEN
 preserve_hierarchy: true
 files:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -85,8 +85,8 @@ const config = {
               label: 'Current',
             },
           },
-          //editUrl:
-            //'https://github.com/kaiachain/kaia-docs/tree/main/',
+          editUrl:
+            'https://github.com/kaiachain/kaia-docs/tree/main/',
           
           docRootComponent: "@theme/DocRoot",
           docItemComponent: "@theme/ApiItem"
@@ -211,6 +211,13 @@ const config = {
         appId: '3JXBTKO6ZU',
         apiKey: '3ae6c772dbecf845225e7ef3f4ac18be',
         indexName: 'klaytn',
+      },
+      announcementBar: {
+        id: 'docs_archive',
+        content: '<div style="font-size: 15px">📢 Welcome to the Kaia documentation! Kaia docs is now open, but <b>some content is still being updated to reflect the transition from Klaytn and may refer to outdated information until July.</b> Thank you for your understanding. 🙏🏻</div>',
+        backgroundColor: '#789806',
+        textColor: '#FFFFFF',
+        isCloseable: true,
       },
       navbar: {
         title: 'Kaia Docs',


### PR DESCRIPTION
## Proposed changes

- Add site update notification ("Kaia docs is now open, but some content is still being updated to reflect the transition from Klaytn and may refer to outdated information until July. Thank you for your understanding."). It's a temporary notice asking for understanding of outdate information due to ongoing updates until the major content update is completed.
- Replace the instances of "Klaytn" with "Kaia" in README.md and CONTRIBUTION.md

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Minor Issues and Typos
- [ ] Major Content Contribution
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to reach out. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn-docs/blob/master/CONTRIBUTING.md)
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn-docs)
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues


## Further comments
