### PR TITLE
updated all that node endpoint url

### DIFF
--- a/docs/references/service-providers/public-en.md
+++ b/docs/references/service-providers/public-en.md
@@ -46,7 +46,7 @@ Since we cannot guarantee uptime and stability of the endpoints, do not use them
 |---|---|---|---|
 |[Kaia Foundation](https://www.klaytn.foundation)|`https://public-en-baobab.klaytn.net`|klay,eth,net|Full|
 ||`https://archive-en.baobab.klaytn.net/`|klay,eth,net|Archive|
-|[All That Node](www.allthatnode.com)|`https://klaytn-baobab-rpc.allthatnode.com:8551`|klay,eth,net|Full|
+|[All That Node](www.allthatnode.com)|`https://klaytn-baobab.g.allthatnode.com/full/evm`|klay,eth,net|Full|
 |[BlockPI Network](https://blockpi.io/)|`https://klaytn-baobab.blockpi.network/v1/rpc/public`|klay,eth,net|Full|
 
 **WebSocket** 

--- a/docs/references/service-providers/public-en.md
+++ b/docs/references/service-providers/public-en.md
@@ -25,7 +25,7 @@ Since we cannot guarantee uptime and stability of the endpoints, do not use them
 |---|---|---|---|
 |[Kaia Foundation](https://www.klaytn.foundation)|`https://public-en-cypress.klaytn.net`|klay,eth,net|Full|
 ||`https://archive-en.cypress.klaytn.net`|klay,eth,net|Archive|
-|[All That Node](www.allthatnode.com)|`https://klaytn-mainnet-rpc.allthatnode.com:8551`|klay,eth,net|Full|
+|[All That Node](www.allthatnode.com)|`https://klaytn-mainnet.g.allthatnode.com/full/evm`|klay,eth,net|Full|
 |[BlockPI Network](https://blockpi.io/)|`https://klaytn.blockpi.network/v1/rpc/public`|klay,eth,net|Full|
 |[OnFinality](https://onfinality.io/)|`https://klaytn.api.onfinality.io/public`|klay,eth,net|Full|
 |[Pokt Network](https://pokt.network/)|`https://klaytn-rpc.gateway.pokt.network/`|klay,eth,net|Full|


### PR DESCRIPTION
Allthatnode changed their RPC endpoint URL to https://klaytn-mainnet.g.allthatnode.com/full/evm. 
Source: https://www.allthatnode.com/klaytn.dsrv

## Proposed changes

- Describe your changes to communicate to the maintainers why we should accept this pull request.
- If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

Please put an x in the boxes related to your change.

- [ x] Minor Issues and Typos
- [ ] Major Content Contribution
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to reach out. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia-docs/blob/main/CONTRIBUTING.md)
- [ ] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribute
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large content contribution, kick off the discussion by explaining why you would suggest the content contribution, etc...