### PR TITLE
Update KeyStore encryption examples in ethers-ext and web3js-ext

### DIFF
--- a/docs/references/sdk/ethers-ext/account-management/keystore/keystoreV3.mdx
+++ b/docs/references/sdk/ethers-ext/account-management/keystore/keystoreV3.mdx
@@ -1,0 +1,135 @@
+# Keystore Encryption and Decryption.
+This example demonstrates how to encrypt and decrypt **keystore V3**.
+
+<CH.Spotlight>
+
+<CH.Code>
+
+```js keystoreV3.js
+const { Wallet } = require("@klaytn/ethers-ext");
+
+// Eth V3. ethers.Wallet.createRandom().encrypt("password")
+const encryptedKey = {
+  "address": "029e786304c1531af3ac7db24a02448e543a099e",
+  "id": "9d492c95-b9e3-42e3-af73-5c77e932208d",
+  "version": 3,
+  "crypto": {
+    "cipher": "aes-128-ctr",
+    "cipherparams": {"iv": "bfcb88a1501e2bb1e6694c03da18953d"},
+    "ciphertext": "076510b4e25d5cfc31239bffcad6036fe543cbbb04b9f3ec719bf4f61b58fc05",
+    "kdf": "scrypt",
+    "kdfparams": {
+      "salt": "79124f05995aae98b3088d8365f59a6dfadd1c9ed249abae3c07733f4cbbee53",
+      "n": 131072,
+      "dklen": 32,
+      "p": 1,
+      "r": 8
+    },
+    "mac": "d70f83824c2c30dc5cd3a244d87147b6aa713a6000165789a82a467651284ac7"
+  }
+};
+// const address = "0x029e786304c1531aF3aC7db24A02448e543A099E";
+// const key = "0x1b33a48f58d8c85ab142a7375fcf18714d88271f6647cfa6b54f1be66b05a762";
+
+const password = "password";
+const password2 = "password2";
+
+async function main() {
+  const account = Wallet.fromEncryptedJsonSync(encryptedKey, password);
+
+  console.log("\ndecrypted address");
+  console.log(account.address);
+
+  console.log("\ndecrypted privateKey");
+  console.log(account.privateKey);
+
+  account.encrypt(password2).then((encryptedKey2) => {
+    const account2 = Wallet.fromEncryptedJsonSync(encryptedKey2, password2);
+
+    console.log("\ndecrypted address with new password");
+    console.log( account2.address );
+
+    console.log("\ndecrypted privateKey with new password");
+    console.log(account2.privateKey);
+  });
+}
+
+main();
+
+
+```
+
+---
+
+```zsh output
+❯ node keystoreV3.js
+
+decrypted address
+0x029e786304c1531af3ac7db24a02448e543a099e
+
+decrypted privateKey
+0x1b33a48f58d8c85ab142a7375fcf18714d88271f6647cfa6b54f1be66b05a762
+
+decrypted address with new password
+0x029e786304c1531af3ac7db24a02448e543a099e
+
+decrypted privateKey with new password
+0x1b33a48f58d8c85ab142a7375fcf18714d88271f6647cfa6b54f1be66b05a762
+```
+
+</CH.Code>
+
+---
+Import the Wallet class from the **@klaytn/ethers-ext** package.
+
+```js keystoreV3.js focus=1
+
+```
+
+---
+**Encrypted key** and **password** information are declared.
+```js keystoreV3.js focus=3:27
+
+```
+
+---
+You can also create a encrypted key with the **ethers.Wallet.createRandom().encrypt()** function.
+```js keystoreV3.js focus=3
+
+```
+
+---
+Decrypt **account** from the **encryptedKey** with the **password**.
+```js keystoreV3.js focus=30
+
+```
+
+---
+You can check address and privateKey of the **account**. 
+```js keystoreV3.js focus=32:36
+
+```
+
+---
+Encrypt the **account** with another password **password2**. And it will make another **encryptedKey2**. 
+
+```js keystoreV3.js focus=38
+
+```
+
+---
+Re-decrypt the **account2** from **encryptedKey2** with **password2** and check if the address and privateKey of the **account2** are same with the info of the **account** from **encryptedKey**. 
+
+```js keystoreV3.js focus=39:45
+
+```
+
+---
+Execute the main function.
+
+```js keystoreV3.js focus=49
+
+```
+
+---
+</CH.Spotlight>

--- a/docs/references/sdk/ethers-ext/sidebar.js
+++ b/docs/references/sdk/ethers-ext/sidebar.js
@@ -38,6 +38,13 @@ export const sidebar = {
                         'references/sdk/ethers-ext/account-management/sign-message/role-based-recover-msg',
                     ],
                 },
+                {
+                    type: 'category', 
+                    label: 'keystore',
+                    items: [
+                        'references/sdk/ethers-ext/account-management/keystore/keystoreV3',
+                    ],
+                },
             ],
         },
         {

--- a/docs/references/sdk/web3js-ext/account-management/keystore/keystoreV3.mdx
+++ b/docs/references/sdk/web3js-ext/account-management/keystore/keystoreV3.mdx
@@ -1,0 +1,158 @@
+# Keystore Encryption and Decryption.
+This example demonstrates how to encrypt and decrypt **keystore V3**.
+
+<CH.Spotlight>
+
+<CH.Code>
+
+```js keystoreV3.js
+const { Web3 } = require("@klaytn/web3js-ext");
+
+const provider = new Web3.providers.HttpProvider("https://public-en-baobab.klaytn.net");
+const web3 = new Web3(provider);
+
+// Web3 V3. web3.eth.accounts.create(1).encrypt("password")
+const encryptedKey = `{
+    "address": "029e786304c1531af3ac7db24a02448e543a099e",
+    "id": "9d492c95-b9e3-42e3-af73-5c77e932208d",
+    "version": 3,
+    "crypto": {
+      "cipher": "aes-128-ctr",
+      "cipherparams": {"iv": "bfcb88a1501e2bb1e6694c03da18953d"},
+      "ciphertext": "076510b4e25d5cfc31239bffcad6036fe543cbbb04b9f3ec719bf4f61b58fc05",
+      "kdf": "scrypt",
+      "kdfparams": {
+        "salt": "79124f05995aae98b3088d8365f59a6dfadd1c9ed249abae3c07733f4cbbee53",
+        "n": 131072,
+        "dklen": 32,
+        "p": 1,
+        "r": 8
+      },
+      "mac": "d70f83824c2c30dc5cd3a244d87147b6aa713a6000165789a82a467651284ac7"
+    }
+  }`;
+// const address = "0x029e786304c1531aF3aC7db24A02448e543A099E";
+// const key = "0x1b33a48f58d8c85ab142a7375fcf18714d88271f6647cfa6b54f1be66b05a762";
+
+const password = "password";
+const password2 = "password2";
+
+async function main() {
+  web3.eth.accounts.wallet.decrypt([JSON.parse(encryptedKey)], password).then((account) => {
+    console.log("\ndecrypted address");
+    console.log(account[0].address);
+
+    console.log("\ndecrypted privateKey");
+    console.log(account[0].privateKey);
+
+    web3.eth.accounts.wallet.encrypt(password2).then((encryptedKey2) => {
+      // Delete account before adding the same account already existing in the wallet.
+      web3.eth.accounts.wallet.remove(encryptedKey2[0].address);
+
+      web3.eth.accounts.wallet.decrypt(encryptedKey2, password2).then((account2) => {
+        console.log("\ndecrypted address with new password");
+        console.log(account2[0].address);
+
+        console.log("\ndecrypted privateKey with new password");
+        console.log(account2[0].privateKey);
+      });
+    });
+  });
+}
+
+main();
+
+```
+
+---
+
+```zsh output
+❯ node keystoreV3.js
+
+decrypted address
+0x029e786304c1531af3ac7db24a02448e543a099e
+
+decrypted privateKey
+0x1b33a48f58d8c85ab142a7375fcf18714d88271f6647cfa6b54f1be66b05a762
+
+decrypted address with new password
+0x029e786304c1531af3ac7db24a02448e543a099e
+
+decrypted privateKey with new password
+0x1b33a48f58d8c85ab142a7375fcf18714d88271f6647cfa6b54f1be66b05a762
+```
+
+</CH.Code>
+
+---
+Import the Web3 class from the **@klaytn/web3js-ext** package.
+
+```js keystoreV3.js focus=1
+
+```
+
+---
+Set up the **provider** and define a **web3** instance using the provider.
+
+```js keystoreV3.js focus=3:4
+
+```
+
+---
+**Encrypted key** and **password** information are declared.
+
+```js keystoreV3.js focus=6:30
+
+```
+
+---
+You can also create a key with the **web3.eth.accounts.create().encrypt()** function.
+
+```js keystoreV3.js focus=6
+
+```
+
+---
+Decrypt **account** from the **encryptedKey** with the **password**.
+
+```js keystoreV3.js focus=33
+
+```
+
+---
+You can check address and privateKey of the **account**. 
+
+```js keystoreV3.js focus=34:38
+
+```
+
+---
+Encrypt the account with another **password2**. And it will make another **encryptedKey2**. 
+
+```js keystoreV3.js focus=40
+
+```
+
+---
+Re-decrypt the **account2** from **encryptedKey2** with **password2** and check if the address and privateKey of the **account2** are same with the info of the **account** from **encryptedKey**. 
+
+```js keystoreV3.js focus=44:50
+
+```
+
+---
+Because the **account2** is same to **account** and already exists in the wallet, so we need to delete existing **account** with the **web3.eth.accounts.wallet.remove()** function before re-decrypting **account2**.
+
+```js keystoreV3.js focus=42
+
+```
+
+---
+Execute the main function.
+
+```js keystoreV3.js focus=55
+
+```
+
+---
+</CH.Spotlight>

--- a/docs/references/sdk/web3js-ext/sidebar.js
+++ b/docs/references/sdk/web3js-ext/sidebar.js
@@ -38,6 +38,13 @@ export const sidebar = {
                         'references/sdk/web3js-ext/account-management/sign-message/role-based-recover-msg',
                     ],
                 },
+                {
+                    type: 'category', 
+                    label: 'keystore',
+                    items: [
+                        'references/sdk/web3js-ext/account-management/keystore/keystoreV3',
+                    ],
+                },
             ],
         },
         {


### PR DESCRIPTION
## Proposed changes

- Update KeyStore encryption example in ethers-ext
- Create KeyStore encryption example in web3js-ext

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Minor Issues and Typos
- [x] Major Content Contribution
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia-docs/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribute
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- N/A

## Further comments

- N/A