### PR TITLE
Enable docs-first mode

### DIFF
--- a/docs/build/tutorials/kaikas-dapp-integration.md
+++ b/docs/build/tutorials/kaikas-dapp-integration.md
@@ -7,7 +7,7 @@
 3. [Providers](#3-providers)
 
 ## Introduction
-[Kaikas](https://docs.kaikas.io) is a non-custodial wallet, similar to [Metamask](https://metamask.io), with additional support for Kaia-specific [Transactions](https://docs.klaytn.foundation/docs/learn/transactions) & [Accounts](https://docs.klaytn.foundation/docs/learn/accounts). This article will guide you through integrating [Kaikas](https://docs.kaikas.io) with a decentralized application (dApp), from High-level (abstract) to Low-level (fine-grained) implementations.
+[Kaikas](https://docs.kaikas.io) is a non-custodial wallet, similar to [Metamask](https://metamask.io), with additional support for Kaia-specific [Transactions](https://docs.kaia.io/learn/transactions) & [Accounts](https://docs.kaia.io/learn/accounts). This article will guide you through integrating [Kaikas](https://docs.kaikas.io) with a decentralized application (dApp), from High-level (abstract) to Low-level (fine-grained) implementations.
 
 For the sake of this guide, we will be dividing Kaikas dApp integration into three main categories:
 
@@ -27,7 +27,7 @@ Many dApps utilize frontend frameworks for state management & delivering reactiv
 
 UI Libraries provide components for user interactions, like `ConnectWallet` component. They also save you the hassle of managing low-level states, like Multiple Accounts & Multiple Networks. You can look at the underlying [Utility Library](#2-utility-libraries) or [Provider](#3-providers) for complex or low-level interactions.
 
-While most UI libraries have built-in support for Metamask, integrating Kaikas is also easy since its [API](https://docs.klaytn.foundation/docs/references/json-rpc) is built on [Metamask's](https://docs.metamask.io/wallet/reference/json-rpc-api). Even if a library doesn't natively support Kaikas, extending it for Kaikas integration is straightforward. For example, these are 2 popular libraries for [React](https://react.dev) or [Next.js](https://nextjs.org):
+While most UI libraries have built-in support for Metamask, integrating Kaikas is also easy since its [API](https://docs.kaia.io/references/json-rpc/kaia/account-created/) is built on [Metamask's](https://docs.metamask.io/wallet/reference/json-rpc-api). Even if a library doesn't natively support Kaikas, extending it for Kaikas integration is straightforward. For example, these are 2 popular libraries for [React](https://react.dev) or [Next.js](https://nextjs.org):
 
 * [Web3Modal](#1.1-web3modal-example)
 * [Web3-Onboard](#1.2-web3-onboard-example)
@@ -87,7 +87,7 @@ Using Utility Libraries to connect an account or send native tokens (e.g., KAIA/
 
 ### 2.1. web3klaytn
 
-[web3klaytn](https://github.com/klaytn/web3klaytn) is a set of drop-in extensions for other Utility Libraries, like [ethers.js](https://docs.ethers.io/v6) & [web3.js](https://web3js.org). It allows you to use your preferred library while exposing first-party support for [Kaia-specific methods](https://docs.klaytn.foundation/docs/references/json-rpc):
+[web3klaytn](https://github.com/klaytn/web3klaytn) is a set of drop-in extensions for other Utility Libraries, like [ethers.js](https://docs.ethers.io/v6) & [web3.js](https://web3js.org). It allows you to use your preferred library while exposing first-party support for [Kaia-specific methods](https://docs.kaia.io/references/json-rpc/kaia/account-created/):
 
 * Transaction, Account, & Account Key types
 * Fee Delegation
@@ -113,4 +113,4 @@ Example Code: [kaikas-ethersjs](https://github.com/klaytn/examples/tree/main/too
 
 ## 3. Providers
 
-At the lowest level is the Provider, [`window.klaytn`](https://docs.kaikas.io/02_api_reference/01_klaytn_provider) (Kaikas itself). You might prefer [Utility Libraries](#2-utility-libraries), but knowledge of Provider APIs helps debug & understand how dependent libraries work. Referring to [Kaia's JSON-RPC API][Kaia-API] is necessary for using Kaia-specific methods like [`kaia_getAccount`](https://docs.klaytn.foundation/docs/references/json-rpc/klay/get-account), [`kaia_sendTransactionAsFeePayer`](https://docs.klaytn.foundation/docs/references/json-rpc/klay/send-transaction-as-fee-payer), & more.
+At the lowest level is the Provider, [`window.klaytn`](https://docs.kaikas.io/02_api_reference/01_klaytn_provider) (Kaikas itself). You might prefer [Utility Libraries](#2-utility-libraries), but knowledge of Provider APIs helps debug & understand how dependent libraries work. Referring to [Kaia's JSON-RPC API][Kaia-API] is necessary for using Kaia-specific methods like [`kaia_getAccount`](https://docs.kaia.io/references/json-rpc/kaia/get-account/), [`kaia_sendTransactionAsFeePayer`](https://docs.kaia.io/references/json-rpc/kaia/send-transaction-as-fee-payer/), & more.

--- a/docs/build/tutorials/scaffold-eth.md
+++ b/docs/build/tutorials/scaffold-eth.md
@@ -18,7 +18,7 @@ To get started with in this guide, you will need:
 * Familiarity with Javascript and React basics such as hooks
 * [Metamask Wallet](https://metamask.io/download/)
 * Test KAIA from [Faucet](https://kairos.wallet.kaia.io/faucet)
-* RPC Endpoint: you can obtain this from one of the supported [endpoint providers](https://docs.kaia.io/docs/references/public-en/)
+* RPC Endpoint: you can obtain this from one of the supported [endpoint providers](https://docs.kaia.io/references/public-en/)
 
 ## Setting up development environment <a href="#setting-up-dev-environment" id="setting-up-dev-environment"></a>
 
@@ -106,7 +106,7 @@ kaia: {
 },
 ```
 
-For more information on using Hardhat with Kaia, please check [Hardhat guide](https://docs.kaia.io/docs/build/get-started/hardhat/) for more details.
+For more information on using Hardhat with Kaia, please check [Hardhat guide](https://docs.kaia.io/build/get-started/hardhat/) for more details.
 
 ### Deploy Contract to Kaia
 After configuring Hardhat to support the Kaia network, the next step is to compile and deploy the sample contract. 
@@ -173,7 +173,7 @@ As you can see above, to verify your contracts, you have to pass in the network 
 ![Verify on Klaytnscope](/img/build/tutorials/sc-verify-klaytnscope.png)
 
 
-For more information about verifying smart contracts on Kaia using the Hardhat Verify plugin, please refer to the H[ardhat-Verify-Plugins guide](https://docs.kaia.io/docs/build/smart-contracts/verify/hardhat/).
+For more information about verifying smart contracts on Kaia using the Hardhat Verify plugin, please refer to the H[ardhat-Verify-Plugins guide](https://docs.kaia.io/build/smart-contracts/verify/hardhat/).
 
 ## Next.js Configuration <a href="#nextjs-configuration" id="nextjs-configuration"></a>
 

--- a/docs/nodes/core-cell/system-requirements.md
+++ b/docs/nodes/core-cell/system-requirements.md
@@ -19,7 +19,7 @@ The following sections show the recommended specifications for both CNs and PNs.
 
 Note that this is a recommended hardware specification for CNs and PNs, not an exact requirement. Any physical machine with similar hardware configurations would be sufficient to operate a CN or a PN.
 
-You can use and apply a live-pruning option to use live-pruning DB. For more details, please refer https://docs.klaytn.foundation/docs/learn/storage/live-pruning/. However, note that live-pruning spec is not recommended for CNs but this may change in the future.
+You can use and apply a live-pruning option to use live-pruning DB. For more details, please refer https://docs.kaia.io/learn/storage/live-pruning/. However, note that live-pruning spec is not recommended for CNs but this may change in the future.
 
 ### Cloud VM <a id="cloud-vm"></a>
 

--- a/docs/references/sdk/viem/viem.md
+++ b/docs/references/sdk/viem/viem.md
@@ -39,7 +39,7 @@ In this tutorial, we will create a bunch of scripts file to read data from the b
 
 ### 2. Set up Public Client & Transport
 
-Firstly, you need to set up your Public [Client](https://viem.sh/docs/clients/intro) with a desired [Transport](https://viem.sh/docs/clients/intro) & [Chain](https://viem.sh/docs/chains/introduction). A Public Client is an interface to **public** [JSON-RPC API](https://docs.klaytn.foundation/docs/references/public-en/) methods such as retrieving block numbers, transactions, reading from smart contracts, etc through [Public Actions](https://viem.sh/docs/actions/public/introduction).
+Firstly, you need to set up your Public [Client](https://viem.sh/docs/clients/intro) with a desired [Transport](https://viem.sh/docs/clients/intro) & [Chain](https://viem.sh/docs/chains/introduction). A Public Client is an interface to **public** [JSON-RPC API](https://docs.kaia.io/references/public-en/) methods such as retrieving block numbers, transactions, reading from smart contracts, etc through [Public Actions](https://viem.sh/docs/actions/public/introduction).
 
 ```ts
 import { createPublicClient, http } from 'viem'

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -64,10 +64,9 @@ const config = {
       'classic',
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
-        blog: {
-          showReadingTime: true,
-        },
+        blog: false,
         docs: {
+          routeBasePath: '/', // Serve the docs at the site's root
           beforeDefaultRemarkPlugins: [
             [
               remarkCodeHike, { 
@@ -113,7 +112,7 @@ const config = {
           web3rpcKlay: {
             // template: "api.mustache",
             specPath: "./web3rpc/yaml/web3rpc-klay.yaml",
-            outputDir: "docs/references/json-rpc/klay",
+            outputDir: "references/json-rpc/klay",
             sidebarOptions: { // optional, instructs plugin to generate sidebar.js
               groupPathsBy: "tag", // group sidebar items by operation "tag"
               categoryLinkSource: "tag",
@@ -122,7 +121,7 @@ const config = {
           web3rpcKaia: {
             // template: "api.mustache",
             specPath: "./web3rpc/yaml/web3rpc-kaia.yaml",
-            outputDir: "docs/references/json-rpc/kaia",
+            outputDir: "references/json-rpc/kaia",
             sidebarOptions: { // optional, instructs plugin to generate sidebar.js
               groupPathsBy: "tag", // group sidebar items by operation "tag"
               categoryLinkSource: "tag",
@@ -130,7 +129,7 @@ const config = {
           },
           web3rpcEth: {
             specPath: "./web3rpc/yaml/web3rpc-eth.yaml",
-            outputDir: "docs/references/json-rpc/eth",
+            outputDir: "references/json-rpc/eth",
             sidebarOptions: { // optional, instructs plugin to generate sidebar.js
               groupPathsBy: "tag", // group sidebar items by operation "tag"
               categoryLinkSource: "tag",
@@ -138,7 +137,7 @@ const config = {
           },
           web3rpcDebug: {
             specPath: "./web3rpc/yaml/web3rpc-debug.yaml",
-            outputDir: "docs/references/json-rpc/debug",
+            outputDir: "references/json-rpc/debug",
             sidebarOptions: { // optional, instructs plugin to generate sidebar.js
               groupPathsBy: "tag", // group sidebar items by operation "tag"
               categoryLinkSource: "tag",
@@ -146,7 +145,7 @@ const config = {
           },
           web3rpcAdmin: {
             specPath: "./web3rpc/yaml/web3rpc-admin.yaml",
-            outputDir: "docs/references/json-rpc/admin",
+            outputDir: "references/json-rpc/admin",
             sidebarOptions: { // optional, instructs plugin to generate sidebar.js
               groupPathsBy: "tag", // group sidebar items by operation "tag"
               categoryLinkSource: "tag",
@@ -154,7 +153,7 @@ const config = {
           },
           web3rpcPersonal: {
             specPath: "./web3rpc/yaml/web3rpc-personal.yaml",
-            outputDir: "docs/references/json-rpc/personal",
+            outputDir: "references/json-rpc/personal",
             sidebarOptions: { // optional, instructs plugin to generate sidebar.js
               groupPathsBy: "tag", // group sidebar items by operation "tag"
               categoryLinkSource: "tag",
@@ -162,7 +161,7 @@ const config = {
           },
           web3rpcNet: {
             specPath: "./web3rpc/yaml/web3rpc-net.yaml",
-            outputDir: "docs/references/json-rpc/net",
+            outputDir: "references/json-rpc/net",
             sidebarOptions: { // optional, instructs plugin to generate sidebar.js
               groupPathsBy: "tag", // group sidebar items by operation "tag"
               categoryLinkSource: "tag",
@@ -170,7 +169,7 @@ const config = {
           },
           web3rpcGovernance: {
             specPath: "./web3rpc/yaml/web3rpc-governance.yaml",
-            outputDir: "docs/references/json-rpc/governance",
+            outputDir: "references/json-rpc/governance",
             sidebarOptions: { // optional, instructs plugin to generate sidebar.js
               groupPathsBy: "tag", // group sidebar items by operation "tag"
               categoryLinkSource: "tag",
@@ -178,7 +177,7 @@ const config = {
           },
           web3rpcTxpool: {
             specPath: "./web3rpc/yaml/web3rpc-txpool.yaml",
-            outputDir: "docs/references/json-rpc/txpool",
+            outputDir: "references/json-rpc/txpool",
             sidebarOptions: { // optional, instructs plugin to generate sidebar.js
               groupPathsBy: "tag", // group sidebar items by operation "tag"
               categoryLinkSource: "tag",
@@ -186,7 +185,7 @@ const config = {
           },
           web3rpcMainbridge: {
             specPath: "./web3rpc/yaml/web3rpc-mainbridge.yaml",
-            outputDir: "docs/references/json-rpc/mainbridge",
+            outputDir: "references/json-rpc/mainbridge",
             sidebarOptions: { // optional, instructs plugin to generate sidebar.js
               groupPathsBy: "tag", // group sidebar items by operation "tag"
               categoryLinkSource: "tag",
@@ -194,7 +193,7 @@ const config = {
           },
           web3rpcSubbridge: {
             specPath: "./web3rpc/yaml/web3rpc-subbridge.yaml",
-            outputDir: "docs/references/json-rpc/subbridge",
+            outputDir: "references/json-rpc/subbridge",
             sidebarOptions: { // optional, instructs plugin to generate sidebar.js
               groupPathsBy: "tag", // group sidebar items by operation "tag"
               categoryLinkSource: "tag",
@@ -223,7 +222,7 @@ const config = {
       },
       announcementBar: {
         id: 'docs_archive',
-        content: '<div style="font-size: 15px">📢 Kaia docs content is still being updated to reflect the transition from Klaytn and <b>may refer to outdated information until July.</b> 🙏🏻 See <b><a target="_blank" href="https://docs.kaia.io/docs/misc/faq-chain-transition/">Klatyn to Kaia Transition FAQ</a></b> first!</div>',
+        content: '<div style="font-size: 15px">📢 Kaia docs content is still being updated to reflect the transition from Klaytn and <b>may refer to outdated information until July.</b> 🙏🏻 See <b><a target="_blank" href="https://docs.kaia.io/misc/faq-chain-transition/">Klatyn to Kaia Transition FAQ</a></b> first!</div>',
         backgroundColor: '#789806',
         textColor: '#FFFFFF',
         isCloseable: true,
@@ -238,31 +237,31 @@ const config = {
         },
         items: [
           {
-            to: "docs/learn",
+            to: "learn",
             position: 'left',
             sidebarid: 'learnSidebar',
             label: 'Learn',
           },
           {
-            to: "docs/build",
+            to: "build",
             position: 'left',
             sidebarid: 'buildSidebar',
             label: 'Build',
           },
           {
-            to: "docs/nodes",
+            to: "nodes",
             position: 'left',
             sidebarid: 'nodeSidebar',
             label: 'Nodes',
           },
           {
-            to: "docs/references",
+            to: "references",
             position: 'left',
             sidebarid: 'refSidebar',
             label: 'References',
           },
           {
-            to: "docs/kaiatech",
+            to: "kaiatech",
             position: 'left',
             sidebarid: 'kaiaSidebar',
             label: 'Kaia Tech',

--- a/sidebars.js
+++ b/sidebars.js
@@ -374,10 +374,10 @@ const sidebars = {
       label: 'SDKs and Libraries',
       link: {type: 'doc', id: 'references/sdk/sdk'},
       items: [
-        // require("./docs/references/sdk/ethers-ext/sidebar").sidebar,
-        // require("./docs/references/sdk/web3js-ext/sidebar").sidebar,
-        // require("./docs/references/sdk/web3j-ext/sidebar").sidebar,
-        // require("./docs/references/sdk/web3py-ext/sidebar").sidebar,
+        // require("./references/sdk/ethers-ext/sidebar").sidebar,
+        // require("./references/sdk/web3js-ext/sidebar").sidebar,
+        // require("./references/sdk/web3j-ext/sidebar").sidebar,
+        // require("./references/sdk/web3py-ext/sidebar").sidebar,
         {
           type: 'category',
           label: 'caver-js',


### PR DESCRIPTION
## Proposed changes

Currently, all docs content will be served under the subroute docs/. (e.g. https://docs.kaia.io/docs/learn/accounts/ ) But our docs domain (docs.kaia.io) only has docs and no other content type (e.g. blog) will be hosted under the same domain name than docs. Thus, I propose to put kaia docs at the root by enabling the Docs-first mode as shown in the following example:

- AS-IS: https://docs.kaia.io/docs/learn/accounts/
- TO-BE: https://docs.kaia.io/learn/accounts/

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Minor Issues and Typos
- [ ] Major Content Contribution
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to reach out. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia-docs/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribute
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues


## Further comments
