### PR TITLE
Fix rpc docs generation config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -111,7 +111,7 @@ const config = {
           web3rpcKlay: {
             // template: "api.mustache",
             specPath: "./web3rpc/yaml/web3rpc-klay.yaml",
-            outputDir: "references/json-rpc/klay",
+            outputDir: "docs/references/json-rpc/klay",
             sidebarOptions: { // optional, instructs plugin to generate sidebar.js
               groupPathsBy: "tag", // group sidebar items by operation "tag"
               categoryLinkSource: "tag",
@@ -120,7 +120,7 @@ const config = {
           web3rpcKaia: {
             // template: "api.mustache",
             specPath: "./web3rpc/yaml/web3rpc-kaia.yaml",
-            outputDir: "references/json-rpc/kaia",
+            outputDir: "docs/references/json-rpc/kaia",
             sidebarOptions: { // optional, instructs plugin to generate sidebar.js
               groupPathsBy: "tag", // group sidebar items by operation "tag"
               categoryLinkSource: "tag",
@@ -128,7 +128,7 @@ const config = {
           },
           web3rpcEth: {
             specPath: "./web3rpc/yaml/web3rpc-eth.yaml",
-            outputDir: "references/json-rpc/eth",
+            outputDir: "docs/references/json-rpc/eth",
             sidebarOptions: { // optional, instructs plugin to generate sidebar.js
               groupPathsBy: "tag", // group sidebar items by operation "tag"
               categoryLinkSource: "tag",
@@ -136,7 +136,7 @@ const config = {
           },
           web3rpcDebug: {
             specPath: "./web3rpc/yaml/web3rpc-debug.yaml",
-            outputDir: "references/json-rpc/debug",
+            outputDir: "docs/references/json-rpc/debug",
             sidebarOptions: { // optional, instructs plugin to generate sidebar.js
               groupPathsBy: "tag", // group sidebar items by operation "tag"
               categoryLinkSource: "tag",
@@ -144,7 +144,7 @@ const config = {
           },
           web3rpcAdmin: {
             specPath: "./web3rpc/yaml/web3rpc-admin.yaml",
-            outputDir: "references/json-rpc/admin",
+            outputDir: "docs/references/json-rpc/admin",
             sidebarOptions: { // optional, instructs plugin to generate sidebar.js
               groupPathsBy: "tag", // group sidebar items by operation "tag"
               categoryLinkSource: "tag",
@@ -152,7 +152,7 @@ const config = {
           },
           web3rpcPersonal: {
             specPath: "./web3rpc/yaml/web3rpc-personal.yaml",
-            outputDir: "references/json-rpc/personal",
+            outputDir: "docs/references/json-rpc/personal",
             sidebarOptions: { // optional, instructs plugin to generate sidebar.js
               groupPathsBy: "tag", // group sidebar items by operation "tag"
               categoryLinkSource: "tag",
@@ -160,7 +160,7 @@ const config = {
           },
           web3rpcNet: {
             specPath: "./web3rpc/yaml/web3rpc-net.yaml",
-            outputDir: "references/json-rpc/net",
+            outputDir: "docs/references/json-rpc/net",
             sidebarOptions: { // optional, instructs plugin to generate sidebar.js
               groupPathsBy: "tag", // group sidebar items by operation "tag"
               categoryLinkSource: "tag",
@@ -168,7 +168,7 @@ const config = {
           },
           web3rpcGovernance: {
             specPath: "./web3rpc/yaml/web3rpc-governance.yaml",
-            outputDir: "references/json-rpc/governance",
+            outputDir: "docs/references/json-rpc/governance",
             sidebarOptions: { // optional, instructs plugin to generate sidebar.js
               groupPathsBy: "tag", // group sidebar items by operation "tag"
               categoryLinkSource: "tag",
@@ -176,7 +176,7 @@ const config = {
           },
           web3rpcTxpool: {
             specPath: "./web3rpc/yaml/web3rpc-txpool.yaml",
-            outputDir: "references/json-rpc/txpool",
+            outputDir: "docs/references/json-rpc/txpool",
             sidebarOptions: { // optional, instructs plugin to generate sidebar.js
               groupPathsBy: "tag", // group sidebar items by operation "tag"
               categoryLinkSource: "tag",
@@ -184,7 +184,7 @@ const config = {
           },
           web3rpcMainbridge: {
             specPath: "./web3rpc/yaml/web3rpc-mainbridge.yaml",
-            outputDir: "references/json-rpc/mainbridge",
+            outputDir: "docs/references/json-rpc/mainbridge",
             sidebarOptions: { // optional, instructs plugin to generate sidebar.js
               groupPathsBy: "tag", // group sidebar items by operation "tag"
               categoryLinkSource: "tag",
@@ -192,7 +192,7 @@ const config = {
           },
           web3rpcSubbridge: {
             specPath: "./web3rpc/yaml/web3rpc-subbridge.yaml",
-            outputDir: "references/json-rpc/subbridge",
+            outputDir: "docs/references/json-rpc/subbridge",
             sidebarOptions: { // optional, instructs plugin to generate sidebar.js
               groupPathsBy: "tag", // group sidebar items by operation "tag"
               categoryLinkSource: "tag",

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -89,28 +89,28 @@ const featureList: FeatureType[] = [
     imgSrcLight: img1Light, // Use the light theme image here
     imgSrcDark: img1Dark, // Use the dark theme image here
     description: <Translate>Want to know about Kaia?</Translate>,
-    to: '/docs/learn',
+    to: '/learn',
   },
   {
     title: <Translate>Getting Started</Translate>,
     imgSrcLight: img2Light,
     imgSrcDark: img2Dark,
     description: <Translate>Want to start building on Kaia?</Translate>,
-    to: '/docs/build',
+    to: '/build',
   },
   {
     title: <Translate>Node Operators</Translate>,
     imgSrcLight: img3Light,
     imgSrcDark: img3Dark,
     description: <Translate>Instructions on running Kaia's nodes</Translate>,
-    to: '/docs/nodes',
+    to: '/nodes',
   },
   {
     title: <Translate>API references</Translate>,
     imgSrcLight: img4Light,
     imgSrcDark: img4Dark,
     description: <Translate>APIs and libraries</Translate>,
-    to: '/docs/references',
+    to: '/references',
   },
 ]
 


### PR DESCRIPTION
## Proposed changes

Revert to the original because the incorrect change in rpc docs generation path configuration in PR #51 caused the rpc docs generation to fail.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Minor Issues and Typos
- [ ] Major Content Contribution
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to reach out. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia-docs/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribute
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- PR #51 

## Further comments
