### PR TITLE
Improve Node Package Download Page Table UI and Update "Tag" to "Release Note"

### DIFF
--- a/src/components/NodePackageDownloads/ArchiveRelease.js
+++ b/src/components/NodePackageDownloads/ArchiveRelease.js
@@ -25,8 +25,8 @@ const ArchiveRelease = (props) => {
             <div className="stable-release-table-header-item-release">
               Release
             </div>
-            <div className="stable-release-table-header-item-tag">
-              Tag
+            <div className="stable-release-table-header-item-release_note">
+              Release note
             </div>
             <dev className="stable-release-table-header-item-hardfork">
               Hardfork
@@ -62,10 +62,10 @@ const ArchiveRelease = (props) => {
                     <Accordion allowMultiple={true}>
                       <AccordionItem>
                         <AccordionButton className="stable-release-accordion-button">
-                          <Box as="span" flex="1" textAlign="left" className="stable-release-accordion-box">
+                          <Box as="span" flex="2.3" textAlign="left" className="stable-release-accordion-box">
                             {_release.type.toUpperCase()} {_release.tag_name}
                           </Box>
-                          <div className="stable-release-table-row-item-tag">
+                          <div className="stable-release-table-row-item-release_note">
                             <a
                                 href={`${tabConfig.gitBaseUrls[_release.type]}/releases/tag/${_release.tag_name}`}
                                 target="_blank"
@@ -202,3 +202,4 @@ const ArchiveRelease = (props) => {
 }
 
 export default ArchiveRelease
+

--- a/src/components/NodePackageDownloads/index.css
+++ b/src/components/NodePackageDownloads/index.css
@@ -141,48 +141,75 @@
 
 .stable-release-table-header {
   display: flex;
+  width: 100%;
   flex-direction: row;
   padding: 15px 20px;
   margin-bottom: 10px;
   background-color: var(--docusaurus-highlighted-code-line-bg);
+  border-bottom: 1px solid rgb(171 169 169);
+
 }
 
 .stable-release-table-row {
   display: flex;
+  width: 100%;
   flex-direction: row;
   padding: 10px 20px;
   color: var(--ifm-link-color);
+  
+}
+.stable-release-accordion-box{
+  display: flex;
+  width: 100%;
+  flex-direction: row;
 }
 
-.stable-release-table-header-item-release,
-.stable-release-table-row-item-release {
-  width: 450px;
+
+.stable-release-table-row-item-release{
+  flex: 1;
+  text-align: left;
 }
 
-.stable-release-table-header-item-tag,
-.stable-release-table-row-item-tag {
-  width: 100px;
-  font-size: 16px;
+
+.stable-release-table-header-item-release{
+  flex: 2;
+  text-align: left;
+  font-weight: bold;
+}
+
+.stable-release-table-header-item-release_note,
+.stable-release-table-row-item-release_note {
+  flex: 2; /* Adjust flex-basis as needed */
+  text-align: left;
+  font-weight: bold;
+
 }
 
 .stable-release-table-header-item-hardfork,
 .stable-release-table-row-item-hardfork {
-  width: 120px;
-  font-size: 16px;
+  flex: 2; /* Adjust flex-basis as needed */
+  text-align: left;
+  font-weight: bold;
+
 }
 
 .stable-release-table-header-item-published,
 .stable-release-table-row-item-published {
-  width: 200px;
-  font-size: 15px;
+  flex: 2; /* Adjust flex-basis as needed */
+  text-align: left;
+  font-weight: bold;
+
 }
+
 
 .stable-release-accordion-button {
   background-color: var(--ifm-footer-background-color);
   border: 1px solid rgb(171 169 169);
+  border-top:none;
   padding: 20px;
   cursor: pointer;
 }
+
 
 .stable-release-accordion-box {
   font-size: 16px;
@@ -204,3 +231,19 @@
   background-color: var(--ifm-link-color);
   color: var(--ifm-footer-background-color);
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/components/NodePackageDownloads/index.css
+++ b/src/components/NodePackageDownloads/index.css
@@ -179,3 +179,20 @@
 .stable-release-accordion-box {
   font-size: 16px;
 }
+
+.show-versions-button {
+  background-color: var(--ifm-footer-background-color);
+  color: var(--ifm-link-color);
+  border: 1px solid rgb(171, 169, 169);
+  padding: 10px 20px;
+  cursor: pointer;
+  margin: 10px;
+  border-radius: 5px;
+  font-size: 16px;
+  transition: background-color 0.3s, color 0.3s;
+}
+
+.show-versions-button:hover {
+  background-color: var(--ifm-link-color);
+  color: var(--ifm-footer-background-color);
+}

--- a/src/components/NodePackageDownloads/index.js
+++ b/src/components/NodePackageDownloads/index.js
@@ -1,20 +1,22 @@
-import React, { useEffect, useState } from 'react'
-import StableRelease from './StableRelease'
-import CurrentRelease from './CurrentRelease'
-import Tabs from '@theme/Tabs'
-import TabItem from '@theme/TabItem'
-import './index.css'
+import React, { useEffect, useState } from 'react';
+import StableRelease from './StableRelease';
+import CurrentRelease from './CurrentRelease';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import './index.css';
 
 export default function NodePackageDownloads() {
-  const [releases, setReleases] = useState([])
-  const [currentRelease, setCurrentRelease] = useState()
-  const size = 10
-  const [start, setStart] = useState(0)
-  const [showPaginationButton, setShowPaginationButton] = useState(true)
+  const [releases, setReleases] = useState([]);
+  const [currentRelease, setCurrentRelease] = useState();
+  const [start, setStart] = useState(0);
+  const [showPaginationButton, setShowPaginationButton] = useState(true);
+  const [showStableReleases, setShowStableReleases] = useState(false); // New state variable
+
+  const size = 10;
 
   useEffect(() => {
     fetchReleases();
-  }, [])
+  }, []);
 
   const fetchReleases = () => {
     fetch(
@@ -25,26 +27,26 @@ export default function NodePackageDownloads() {
     )
       .then((response) => response.json())
       .then((response) => {
-        let releasesData = response.data.releases
-        let machineTypes = response.data.machineTypes.filter(item => item.machineType !== "windows")
-        let config = response.data.config
-        setReleases([...releases, ...releasesData])
+        let releasesData = response.data.releases;
+        let machineTypes = response.data.machineTypes.filter(item => item.machineType !== "windows");
+        let config = response.data.config;
+        setReleases([...releases, ...releasesData]);
 
-        let resultFirstRecord
+        let resultFirstRecord;
         if (releasesData && releasesData.length > 0 && start === 0) {
           resultFirstRecord = {
             tagName: releasesData[0].tag_name,
             binaryPrefix: releasesData[0].type,
             githubUrl: config.gitBaseUrls[releasesData[0].type],
             machineTypes: machineTypes,
-          }
+          };
 
-          setCurrentRelease(resultFirstRecord)
+          setCurrentRelease(resultFirstRecord);
         }
-        setStart(start+size);
-        setShowPaginationButton(releasesData.length !== 0)
-      })
-  }
+        setStart(start + size);
+        setShowPaginationButton(releasesData.length !== 0);
+      });
+  };
 
   return (
     <div style={{ marginBottom: '20px' }}>
@@ -70,13 +72,14 @@ export default function NodePackageDownloads() {
           <Tabs groupId="machineTypes">
             {currentRelease.machineTypes.map((_tab, _index) => (
               <TabItem
+                key={_index}
                 value={_tab.machineType.toLocaleLowerCase()}
                 label={_tab.machineType.toUpperCase()}
                 default={_tab.default}
               >
                 <CurrentRelease
                   tabConfig={currentRelease.machineTypes.filter(
-                    (_machine) => _machine.machineType == _tab.machineType
+                    (_machine) => _machine.machineType === _tab.machineType
                   )}
                   releaseData={{
                     tagName: currentRelease.tagName,
@@ -88,72 +91,83 @@ export default function NodePackageDownloads() {
             ))}
           </Tabs>
         ) : (
-          <>
-            <div style={{ width: '100%' }}>
-              <div style={{ margin: '10px auto', width: '100px' }}>
-                <span className="loader"></span>
-              </div>
+          <div style={{ width: '100%' }}>
+            <div style={{ margin: '10px auto', width: '100px' }}>
+              <span className="loader"></span>
             </div>
-          </>
+          </div>
         )}
       </div>
+
       <div style={{ border: '0.5px solid', marginTop: '30px' }}>
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'row',
-            border: '0.5px solid',
-          }}
+        <button
+          onClick={() => setShowStableReleases(!showStableReleases)}
+          className="show-versions-button" // Apply the new class
         >
-          <div
-            style={{
-              fontSize: '20px',
-              fontWeight: 600,
-              padding: '10px',
-              width: '200px',
-              borderRight: '0.5px solid',
-              alignContent: 'center',
-            }}
-          >
-            Stable releases
-          </div>
-          <div style={{ alignContent: 'center', padding: '10px' }}>
-            These are the current and previous releases of Kaia, updated
-            automatically when a new version is tagged in our{' '}
-            <a style={{ textDecoration: 'underline' }} href={currentRelease?.githubUrl}>
-              GitHub repository.
-            </a>
-          </div>
-        </div>
-        {currentRelease && currentRelease.machineTypes ? (
-          <Tabs groupId="machineTypes">
-            {currentRelease.machineTypes.map((_tab, _index) => (
-              <TabItem
-                value={_tab.machineType.toLocaleLowerCase()}
-                label={_tab.machineType.toUpperCase()}
-                default={_tab.default}
+          {showStableReleases ? 'Hide Versions' : 'Show Versions'}
+        </button>
+        {showStableReleases && (
+          <div>
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'row',
+                border: '0.5px solid',
+              }}
+            >
+              <div
+                style={{
+                  fontSize: '20px',
+                  fontWeight: 600,
+                  padding: '10px',
+                  width: '200px',
+                  borderRight: '0.5px solid',
+                  alignContent: 'center',
+                }}
               >
-                <StableRelease
-                  tabConfig={currentRelease.machineTypes.filter(
-                    (_machine) => _machine.machineType == _tab.machineType
-                  )}
-                  releaseData={releases}
-                  fetchReleases={fetchReleases}
-                  showPaginationButton={showPaginationButton}
-                />
-              </TabItem>
-            ))}
-          </Tabs>
-        ) : (
-          <>
-            <div style={{ width: '100%' }}>
-              <div style={{ margin: '10px auto', width: '100px' }}>
-                <span className="loader"></span>
+                Archived Releases 
+              </div>
+              <div style={{ alignContent: 'center', padding: '10px' }}>
+                These are the current and previous releases of Kaia, updated
+                automatically when a new version is tagged in our{' '}
+                <a
+                  style={{ textDecoration: 'underline' }}
+                  href={currentRelease?.githubUrl}
+                >
+                  GitHub repository.
+                </a>
               </div>
             </div>
-          </>
+            {currentRelease && currentRelease.machineTypes ? (
+              <Tabs groupId="machineTypes">
+                {currentRelease.machineTypes.map((_tab, _index) => (
+                  <TabItem
+                    key={_index}
+                    value={_tab.machineType.toLocaleLowerCase()}
+                    label={_tab.machineType.toUpperCase()}
+                    default={_tab.default}
+                  >
+                    <StableRelease
+                      tabConfig={currentRelease.machineTypes.filter(
+                        (_machine) => _machine.machineType === _tab.machineType
+                      )}
+                      releaseData={releases}
+                      fetchReleases={fetchReleases}
+                      showPaginationButton={showPaginationButton}
+                    />
+                  </TabItem>
+                ))}
+              </Tabs>
+            ) : (
+              <div style={{ width: '100%' }}>
+                <div style={{ margin: '10px auto', width: '100px' }}>
+                  <span className="loader"></span>
+                </div>
+              </div>
+            )}
+          </div>
         )}
       </div>
     </div>
-  )
+  );
 }

--- a/src/components/NodePackageDownloads/index.js
+++ b/src/components/NodePackageDownloads/index.js
@@ -1,52 +1,59 @@
-import React, { useEffect, useState } from 'react';
-import StableRelease from './StableRelease';
-import CurrentRelease from './CurrentRelease';
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import './index.css';
+import React, { useEffect, useState } from 'react'
+import StableRelease from './StableRelease'
+import CurrentRelease from './CurrentRelease'
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+import './index.css'
 
 export default function NodePackageDownloads() {
-  const [releases, setReleases] = useState([]);
-  const [currentRelease, setCurrentRelease] = useState();
-  const [start, setStart] = useState(0);
-  const [showPaginationButton, setShowPaginationButton] = useState(true);
-  const [showStableReleases, setShowStableReleases] = useState(false); // New state variable
-
-  const size = 10;
+  const [releases, setReleases] = useState([])
+  const [currentRelease, setCurrentRelease] = useState()
+  const size = 10
+  const [start, setStart] = useState(0)
+  const [showPaginationButton, setShowPaginationButton] = useState(true)
+  const [showVersions, setShowVersions] = useState(false)
+  const [allVersionsLoaded, setAllVersionsLoaded] = useState(false)
 
   useEffect(() => {
-    fetchReleases();
-  }, []);
+    fetchReleases()
+  }, [])
 
   const fetchReleases = () => {
-    fetch(
-      'https://airdrop-api.klaytn.foundation/node/releases?start=' + start,
-      {
-        method: 'GET',
-      }
-    )
+    fetch('https://airdrop-api.klaytn.foundation/node/releases?start=' + start, {
+      method: 'GET',
+    })
       .then((response) => response.json())
       .then((response) => {
-        let releasesData = response.data.releases;
-        let machineTypes = response.data.machineTypes.filter(item => item.machineType !== "windows");
-        let config = response.data.config;
-        setReleases([...releases, ...releasesData]);
+        let releasesData = response.data.releases
+        let machineTypes = response.data.machineTypes.filter(item => item.machineType !== "windows")
+        let config = response.data.config
+        setReleases([...releases, ...releasesData])
 
-        let resultFirstRecord;
+        let resultFirstRecord
         if (releasesData && releasesData.length > 0 && start === 0) {
           resultFirstRecord = {
             tagName: releasesData[0].tag_name,
             binaryPrefix: releasesData[0].type,
             githubUrl: config.gitBaseUrls[releasesData[0].type],
             machineTypes: machineTypes,
-          };
+          }
 
-          setCurrentRelease(resultFirstRecord);
+          setCurrentRelease(resultFirstRecord)
         }
-        setStart(start + size);
-        setShowPaginationButton(releasesData.length !== 0);
-      });
-  };
+        setStart(start + size)
+        setShowPaginationButton(releasesData.length !== 0)
+        if (releasesData.length < size) {
+          setAllVersionsLoaded(true)
+        }
+      })
+  }
+
+  const handleShowVersionsClick = () => {
+    setShowVersions(true)
+    if (!allVersionsLoaded) {
+      fetchReleases()
+    }
+  }
 
   return (
     <div style={{ marginBottom: '20px' }}>
@@ -79,7 +86,7 @@ export default function NodePackageDownloads() {
               >
                 <CurrentRelease
                   tabConfig={currentRelease.machineTypes.filter(
-                    (_machine) => _machine.machineType === _tab.machineType
+                    (_machine) => _machine.machineType == _tab.machineType
                   )}
                   releaseData={{
                     tagName: currentRelease.tagName,
@@ -91,83 +98,72 @@ export default function NodePackageDownloads() {
             ))}
           </Tabs>
         ) : (
-          <div style={{ width: '100%' }}>
-            <div style={{ margin: '10px auto', width: '100px' }}>
-              <span className="loader"></span>
+          <>
+            <div style={{ width: '100%' }}>
+              <div style={{ margin: '10px auto', width: '100px' }}>
+                <span className="loader"></span>
+              </div>
             </div>
-          </div>
+          </>
         )}
       </div>
-
       <div style={{ border: '0.5px solid', marginTop: '30px' }}>
-        <button
-          onClick={() => setShowStableReleases(!showStableReleases)}
-          className="show-versions-button" // Apply the new class
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'row',
+            border: '0.5px solid',
+          }}
         >
-          {showStableReleases ? 'Hide Versions' : 'Show Versions'}
-        </button>
-        {showStableReleases && (
-          <div>
-            <div
-              style={{
-                display: 'flex',
-                flexDirection: 'row',
-                border: '0.5px solid',
-              }}
-            >
-              <div
-                style={{
-                  fontSize: '20px',
-                  fontWeight: 600,
-                  padding: '10px',
-                  width: '200px',
-                  borderRight: '0.5px solid',
-                  alignContent: 'center',
-                }}
+          <div
+            style={{
+              fontSize: '20px',
+              fontWeight: 600,
+              padding: '10px',
+              width: '200px',
+              borderRight: '0.5px solid',
+              alignContent: 'center',
+            }}
+          >
+            Archived releases
+          </div>
+          <div style={{ alignContent: 'center', padding: '10px' }}>
+            These are the current and previous releases of Kaia, updated
+            automatically when a new version is tagged in our{' '}
+            <a style={{ textDecoration: 'underline' }} href={currentRelease?.githubUrl}>
+              GitHub repository.
+            </a>
+          </div>
+        </div>
+        {showVersions && (
+          <Tabs groupId="machineTypes">
+            {currentRelease.machineTypes.map((_tab, _index) => (
+              <TabItem
+                key={_index}
+                value={_tab.machineType.toLocaleLowerCase()}
+                label={_tab.machineType.toUpperCase()}
+                default={_tab.default}
               >
-                Archived Releases 
-              </div>
-              <div style={{ alignContent: 'center', padding: '10px' }}>
-                These are the current and previous releases of Kaia, updated
-                automatically when a new version is tagged in our{' '}
-                <a
-                  style={{ textDecoration: 'underline' }}
-                  href={currentRelease?.githubUrl}
-                >
-                  GitHub repository.
-                </a>
-              </div>
-            </div>
-            {currentRelease && currentRelease.machineTypes ? (
-              <Tabs groupId="machineTypes">
-                {currentRelease.machineTypes.map((_tab, _index) => (
-                  <TabItem
-                    key={_index}
-                    value={_tab.machineType.toLocaleLowerCase()}
-                    label={_tab.machineType.toUpperCase()}
-                    default={_tab.default}
-                  >
-                    <StableRelease
-                      tabConfig={currentRelease.machineTypes.filter(
-                        (_machine) => _machine.machineType === _tab.machineType
-                      )}
-                      releaseData={releases}
-                      fetchReleases={fetchReleases}
-                      showPaginationButton={showPaginationButton}
-                    />
-                  </TabItem>
-                ))}
-              </Tabs>
-            ) : (
-              <div style={{ width: '100%' }}>
-                <div style={{ margin: '10px auto', width: '100px' }}>
-                  <span className="loader"></span>
-                </div>
-              </div>
-            )}
+                <StableRelease
+                  tabConfig={currentRelease.machineTypes.filter(
+                    (_machine) => _machine.machineType == _tab.machineType
+                  )}
+                  releaseData={releases}
+                  fetchReleases={fetchReleases}
+                  showPaginationButton={showPaginationButton}
+                />
+              </TabItem>
+            ))}
+          </Tabs>
+        )}
+        {!showVersions && (
+          <div style={{ textAlign: 'center', margin: '20px' }}>
+            <button onClick={handleShowVersionsClick} className="show-versions-button">
+              Show more versions
+            </button>
           </div>
         )}
       </div>
     </div>
-  );
+  )
 }


### PR DESCRIPTION
This PR introduces the following enhancements to the node package download page:

1. Improved the table UI for better readability and user experience.
2. Changed the label "tag" to "release note" to provide more clarity and visibility.

UI Improvements:
Adjusted column widths and alignments for better presentation of header

Label Update
1. Release Note Update: The label "tag" has been replaced with "release note" in the node package download page table for clarity and consistency.

2. Alignment Correction: Adjusted the alignment of the "hardfork" and "published" headers in the same table to ensure they properly align with their respective column elements.

Screen shot 
Before 
![Screenshot from 2024-07-21 16-53-57](https://github.com/user-attachments/assets/ab6273de-c3b7-469f-ab71-25c78a3a2772)

After 
![Screenshot from 2024-07-21 16-44-34](https://github.com/user-attachments/assets/f6e0bb61-994c-48df-82e9-02691eff92e6)

Testing:

Manually tested the download page on various browsers (Chrome, Firefox, Safari) to ensure the changes render correctly.
Verified that "tag" has been replaced with "release note" and that the links continue to function as expected.



