### PR TITLE
Update file type typos & code spacings

### DIFF
--- a/docs/build/get-started/hardhat.md
+++ b/docs/build/get-started/hardhat.md
@@ -194,7 +194,7 @@ In this section, we would be testing some of our contract functionalities.
 **Step 2**: Copy the code below in the `sbtTest.js` file.
 
 ```js
-// This is an example test file. Hardhat will run every *.ts file in `test/`,
+// This is an example test file. Hardhat will run every *.js file in `test/`,
 // so feel free to add new ones.
 
 // Hardhat tests are normally written with Mocha and Chai.
@@ -259,26 +259,23 @@ describe("Token contract", function () {
       await expect(
         sbtContract.transferFrom(owner.address, addr1.address, 0)
       ).to.be.reverted;
+    });
+
+    it("Should prohibit token transfer using safeTransferFrom", async function () {
+      const { sbtContract, owner, addr1 } = await loadFixture(
+        deployTokenFixture
+      );
+
+      const safemintTx = await sbtContract.safeMint(owner.address);
+
+      // prohibit token transfer of token id (0) from owner to addr1
+      await expect(sbtContract['safeTransferFrom(address,address,uint256)'](
+        owner.address,
+        addr1.address,
+        0 
+      )).to.be.reverted;
+    });
   });
-
-  it("Should prohibit token transfer using safeTransferFrom", async function () {
-    const { sbtContract, owner, addr1 } = await loadFixture(
-      deployTokenFixture
-    );
-
-    const safemintTx = await sbtContract.safeMint(owner.address);
-
-    // prohibit token transfer of token id (0) from owner to addr1
-    await expect(sbtContract['safeTransferFrom(address,address,uint256)'](
-      owner.address,
-      addr1.address,
-      0 
-  )).to.be.reverted;
-});
-
-
-});
-
 })
 ```
 
@@ -292,7 +289,7 @@ The tests above check the following:
 **Step 3**: To run your test, run the command below:
 
 ```bash
-npx hardhat test test/sbtTest.ts 
+npx hardhat test test/sbtTest.js 
 ```
 
 ![](/img/build/get-started/sbtTest.png)

--- a/i18n/ja/docusaurus-plugin-content-docs/current/build/get-started/hardhat.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/build/get-started/hardhat.md
@@ -195,7 +195,7 @@ In this section, we would be testing some of our contract functionalities.
 **Step 2**: Copy the code below in the `sbtTest.js` file.
 
 ```js
-// This is an example test file. Hardhat will run every *.ts file in `test/`,
+// This is an example test file. Hardhat will run every *.js file in `test/`,
 // so feel free to add new ones.
 
 // Hardhat tests are normally written with Mocha and Chai.
@@ -260,26 +260,23 @@ describe("Token contract", function () {
       await expect(
         sbtContract.transferFrom(owner.address, addr1.address, 0)
       ).to.be.reverted;
+    });
+
+    it("Should prohibit token transfer using safeTransferFrom", async function () {
+      const { sbtContract, owner, addr1 } = await loadFixture(
+        deployTokenFixture
+      );
+
+      const safemintTx = await sbtContract.safeMint(owner.address);
+
+      // prohibit token transfer of token id (0) from owner to addr1
+      await expect(sbtContract['safeTransferFrom(address,address,uint256)'](
+        owner.address,
+        addr1.address,
+        0 
+      )).to.be.reverted;
+    });
   });
-
-  it("Should prohibit token transfer using safeTransferFrom", async function () {
-    const { sbtContract, owner, addr1 } = await loadFixture(
-      deployTokenFixture
-    );
-
-    const safemintTx = await sbtContract.safeMint(owner.address);
-
-    // prohibit token transfer of token id (0) from owner to addr1
-    await expect(sbtContract['safeTransferFrom(address,address,uint256)'](
-      owner.address,
-      addr1.address,
-      0 
-  )).to.be.reverted;
-});
-
-
-});
-
 })
 ```
 
@@ -293,7 +290,7 @@ The tests above check the following:
 **Step 3**: To run your test, run the command below:
 
 ```bash
-npx hardhat test test/sbtTest.ts 
+npx hardhat test test/sbtTest.js 
 ```
 
 ![](/img/build/get-started/sbtTest.png)

--- a/i18n/ko/docusaurus-plugin-content-docs/current/build/get-started/hardhat.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/build/get-started/hardhat.md
@@ -195,7 +195,7 @@ contract SoulBoundToken is KIP17, Ownable {
 **2단계**: 아래 코드를 `sbtTest.js` 파일에 복사합니다.
 
 ```js
-// This is an example test file. Hardhat will run every *.ts file in `test/`,
+// This is an example test file. Hardhat will run every *.js file in `test/`,
 // so feel free to add new ones.
 
 // Hardhat tests are normally written with Mocha and Chai.
@@ -260,26 +260,23 @@ describe("Token contract", function () {
       await expect(
         sbtContract.transferFrom(owner.address, addr1.address, 0)
       ).to.be.reverted;
+    });
+
+    it("Should prohibit token transfer using safeTransferFrom", async function () {
+      const { sbtContract, owner, addr1 } = await loadFixture(
+        deployTokenFixture
+      );
+
+      const safemintTx = await sbtContract.safeMint(owner.address);
+
+      // prohibit token transfer of token id (0) from owner to addr1
+      await expect(sbtContract['safeTransferFrom(address,address,uint256)'](
+        owner.address,
+        addr1.address,
+        0 
+      )).to.be.reverted;
+    });
   });
-
-  it("Should prohibit token transfer using safeTransferFrom", async function () {
-    const { sbtContract, owner, addr1 } = await loadFixture(
-      deployTokenFixture
-    );
-
-    const safemintTx = await sbtContract.safeMint(owner.address);
-
-    // prohibit token transfer of token id (0) from owner to addr1
-    await expect(sbtContract['safeTransferFrom(address,address,uint256)'](
-      owner.address,
-      addr1.address,
-      0 
-  )).to.be.reverted;
-});
-
-
-});
-
 })
 ```
 
@@ -293,7 +290,7 @@ describe("Token contract", function () {
 **3단계**: 테스트를 실행하려면 아래 명령을 실행합니다:
 
 ```bash
-npx hardhat test test/sbtTest.ts 
+npx hardhat test test/sbtTest.js 
 ```
 
 ![](/img/build/get-started/sbtTest.png)

--- a/i18n/vi/docusaurus-plugin-content-docs/current/build/get-started/hardhat.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/build/get-started/hardhat.md
@@ -195,7 +195,7 @@ In this section, we would be testing some of our contract functionalities.
 **Step 2**: Copy the code below in the `sbtTest.js` file.
 
 ```js
-// This is an example test file. Hardhat will run every *.ts file in `test/`,
+// This is an example test file. Hardhat will run every *.js file in `test/`,
 // so feel free to add new ones.
 
 // Hardhat tests are normally written with Mocha and Chai.
@@ -260,26 +260,23 @@ describe("Token contract", function () {
       await expect(
         sbtContract.transferFrom(owner.address, addr1.address, 0)
       ).to.be.reverted;
+    });
+
+    it("Should prohibit token transfer using safeTransferFrom", async function () {
+      const { sbtContract, owner, addr1 } = await loadFixture(
+        deployTokenFixture
+      );
+
+      const safemintTx = await sbtContract.safeMint(owner.address);
+
+      // prohibit token transfer of token id (0) from owner to addr1
+      await expect(sbtContract['safeTransferFrom(address,address,uint256)'](
+        owner.address,
+        addr1.address,
+        0 
+      )).to.be.reverted;
+    });
   });
-
-  it("Should prohibit token transfer using safeTransferFrom", async function () {
-    const { sbtContract, owner, addr1 } = await loadFixture(
-      deployTokenFixture
-    );
-
-    const safemintTx = await sbtContract.safeMint(owner.address);
-
-    // prohibit token transfer of token id (0) from owner to addr1
-    await expect(sbtContract['safeTransferFrom(address,address,uint256)'](
-      owner.address,
-      addr1.address,
-      0 
-  )).to.be.reverted;
-});
-
-
-});
-
 })
 ```
 
@@ -293,7 +290,7 @@ The tests above check the following:
 **Step 3**: To run your test, run the command below:
 
 ```bash
-npx hardhat test test/sbtTest.ts 
+npx hardhat test test/sbtTest.js 
 ```
 
 ![](/img/build/get-started/sbtTest.png)


### PR DESCRIPTION
## Proposed changes

- The tutorial regarding first smart contract guides to use .js in the hardhat init CLI, yet in the middle of the tutorial it mentions .ts -> fixed typo regarding this
- Also shifted the spacings for the hardhat test code so that it aligns :)

## Types of changes

Please put an x in the boxes related to your change.

- [x] Minor Issues and Typos
- [ ] Major Content Contribution
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to reach out. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia-docs/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribute
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large content contribution, kick off the discussion by explaining why you would suggest the content contribution, etc...