### PR TITLE
Fix incorrect representation of alt text of image

### DIFF
--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -26,6 +26,7 @@ type FeatureType = {
   imgSrcDark: string; // Add a property for the dark theme image
   description: JSX.Element
   to: string
+  altText: string
 }
 
 const StyledSection = styled.section`
@@ -90,6 +91,7 @@ const featureList: FeatureType[] = [
     imgSrcDark: img1Dark, // Use the dark theme image here
     description: <Translate>Want to know about Kaia?</Translate>,
     to: '/learn',
+    altText: 'Kaia Overview',
   },
   {
     title: <Translate>Getting Started</Translate>,
@@ -97,6 +99,7 @@ const featureList: FeatureType[] = [
     imgSrcDark: img2Dark,
     description: <Translate>Want to start building on Kaia?</Translate>,
     to: '/build',
+    altText: 'Getting Started with Kaia',
   },
   {
     title: <Translate>Node Operators</Translate>,
@@ -104,6 +107,7 @@ const featureList: FeatureType[] = [
     imgSrcDark: img3Dark,
     description: <Translate>Instructions on running Kaia's nodes</Translate>,
     to: '/nodes',
+    altText: 'Kaia Node Operators',
   },
   {
     title: <Translate>API references</Translate>,
@@ -111,17 +115,21 @@ const featureList: FeatureType[] = [
     imgSrcDark: img4Dark,
     description: <Translate>APIs and libraries</Translate>,
     to: '/references',
+    altText: 'Kaia API references',
   },
 ]
 
-function Feature({ imgSrcLight, imgSrcDark, title, description, to }: FeatureType) {
+function Feature({ imgSrcLight, imgSrcDark, title, description, to, altText }: FeatureType) {
   const { colorMode } = useColorMode();
   const imgSrc = colorMode === 'dark' ? imgSrcDark : imgSrcLight;
+
+  const titleText = title.props.message;
+
   return (
     <StyledFeature>
       <Link to={to} style={{ textDecoration: 'none', color: 'inherit' }}>
         <StyledImgBox>
-          <StyledImg src={imgSrc} alt={title.toString()} />
+          <StyledImg src={imgSrc} alt={titleText || altText} />
         </StyledImgBox>
         <StyledContent>
           <h3>{title}</h3>


### PR DESCRIPTION
## Proposed changes

Fix incorrect representation of alt text of image
- **Symptom**: The google search shows “[object Object]” in the metadata description.
![image](https://github.com/user-attachments/assets/7adc8950-aef7-4db5-9979-98d0ee597940)
- **Cause**: The issue lies in how the `alt` attribute for the image is configured in the `Feature` component. When using `alt={title.toString()}`, the title is a JSX element, and directly calling `.toString()` on it doesn't extract the text content as expected. Instead, it returns a string representation of the object, which in this case is `[object Object]`.
- **Solution**: Add fallback `altText` property to each image

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Minor Issues and Typos
- [ ] Major Content Contribution
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to reach out. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia-docs/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribute
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments

