### PR TITLE
Fix flash of unstyled content behavior

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -80,3 +80,15 @@ html[data-theme='dark'] .sidebar-divider {
   height: auto;
   aspect-ratio: auto 300 / 100;
 }
+
+.layout-wrapper {
+  visibility: hidden;
+}
+
+.layout-wrapper.loaded {
+  visibility: visible;
+}
+
+body {
+  overflow-y: auto;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import styled from 'styled-components';
@@ -38,16 +38,28 @@ function HomepageHeader() {
 }
 
 export default function Home() {
-  const { siteConfig } = useDocusaurusContext()
+  const { siteConfig } = useDocusaurusContext();
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsLoaded(true);
+    }, 100);
+
+    return () => clearTimeout(timer);
+  }, []);
+
   return (
     <Layout
       title={`${siteConfig.title}`}
       description="Welcome to the Kaia Docs"
     >
-      <HomepageHeader />
-      <main>
-        <HomepageFeatures />
-      </main>
+      <div className={`layout-wrapper ${isLoaded ? 'loaded' : ''}`}>
+        <HomepageHeader />
+        <main>
+          <HomepageFeatures />
+        </main>
+      </div>
     </Layout>
-  )
+  );
 }

--- a/src/theme/Footer/custom.feedback.css
+++ b/src/theme/Footer/custom.feedback.css
@@ -2,3 +2,16 @@
   --feedback-primary-color: #789806;
   --feedback-button-dark-bg-color: var(--feedback-primary-color);
 }
+
+.feedback-wrapper {
+  visibility: hidden;
+}
+
+.feedback-wrapper.loaded {
+  visibility: visible;
+}
+
+/* Hide the feedback button initially */
+.feedback-wrapper:not(.loaded) pushfeedback-button {
+  display: none;
+}

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React, { useEffect, useState } from 'react';
 import Footer from '@theme-original/Footer';
 
 import { FeedbackButton } from 'pushfeedback-react';
@@ -7,17 +7,35 @@ import 'pushfeedback/dist/pushfeedback/pushfeedback.css';
 import './custom.feedback.css';
 
 export default function FooterWrapper(props) {
+  const [isLoaded, setIsLoaded] = useState(false);
 
-useEffect(() => {
+  useEffect(() => {
     if (typeof window !== 'undefined') {
-    defineCustomElements(window);
+      defineCustomElements(window);
     }
-}, []);
 
-return (
+    // Use the same timing as the main content load
+    const timer = setTimeout(() => {
+      setIsLoaded(true);
+    }, 100);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
     <>
-    <FeedbackButton project="8ou0itrmqd" button-position="bottom-right" modal-position="bottom-right" button-style="dark" modal-title="Your feedback makes a difference. Let us know how we can do better.">Make this page better</FeedbackButton>
-    <Footer {...props} />
+      <div className={`feedback-wrapper ${isLoaded ? 'loaded' : ''}`}>
+        <FeedbackButton
+          project="8ou0itrmqd"
+          button-position="bottom-right"
+          modal-position="bottom-right"
+          button-style="dark"
+          modal-title="Your feedback makes a difference. Let us know how we can do better."
+        >
+          Make this page better
+        </FeedbackButton>
+      </div>
+      <Footer {...props} />
     </>
-)
-}  
+  );
+}


### PR DESCRIPTION
## Proposed changes

Fix flash of unstyled content behavior
- **Symptom**: Whenever the Kaia docs landing page refreshes upon page loading or language switch, the site shows a glimpse of mobile layout (texts and images are aligned vertically) at first, and then quickly shifts to desktop layout (texts and images aligned horizontally), which is typically called "Flash Of Unstyled Content" behavior.

https://github.com/user-attachments/assets/17d2a38a-8352-4913-b129-a2a1ea00ef87


- **Cause**: The browser rendering the page before the styles and content are fully loaded and applied.
- **Solution**: Hide the content until it's fully loaded and styled by using CSS.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Minor Issues and Typos
- [ ] Major Content Contribution
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to reach out. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia-docs/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribute
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

## Further comments
