### PR TITLE
Add note for `NETWORK` and `NETWORK_ID` configuration in AWS AMI docs

### DIFF
--- a/docs/misc/operation/aws-ami.md
+++ b/docs/misc/operation/aws-ami.md
@@ -28,10 +28,6 @@ Kaia provides these 4 types of AMIs for mainnet. There are also AMIs for Kairos 
 See [State Batch Pruning](../../../learn/storage/state-pruning/#state-batch-pruning-state-migration) for more details on state migrated chaindata.
 See [Block Synchronization](../../learn/storage/block-sync.md) for more details on block sync modes.
 
-## AMI generation period
-
-We generate the latest AMI every day around 6 pm KST. Once generated, the AMIs last for 3 days. The AMI has the date of creation appended in the name, such as `kaia-mainnet-clean-en-20240926`.
-
 
 ## Launch new EC2 instance with AMI in Amazon console
 
@@ -72,6 +68,23 @@ $ sudo fio --filename=/dev/nvme1n1 --rw=read --bs=128k --iodepth=32 --ioengine=l
 This task to warmup Amazon EBS volume would take a long time depending on the data size. Refer to `fio` output for the ETA.
 
 :::
+
+### Check `kend.conf` configuration
+
+Before starting the node, check `NETWORK` and `NETWORK_ID` fields in the configuration file `kend.conf`. The `kend.conf` file is located in `/etc/kend/conf/kend.conf`.
+
+For Mainnet, the `NETWORK` field should be `mainnet`. For Kairos, the `NETWORK` field should be `kairos`.
+```
+# for Mainnet
+NETWORK=mainnet
+
+# for Kairos
+NETWORK=kairos
+```
+
+Note that `NETWORK_ID` is only used for private network. Thus make sure not to set `NETWORK_ID` for Mainnet or Kairos.
+
+For more details on `kend.conf`, see [Configuration](configuration.md).
 
 ### Start `kend` service
 


### PR DESCRIPTION
## Proposed changes

- In EN instance created using AWS AMI, the configuration file has `NETWORK_ID` set. However in order to use Mainnet or Kairos, we should use `NETWORK` instead of `NETWORK_ID` (`NETWORK_ID` is for private network).
- This PR add note to make users check their conf file for the `NETWORK` and `NETWORK_ID` field.
- Also, removed obsolete content about AMI generation period.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Minor Issues and Typos
- [x] Major Content Contribution
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to reach out. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia-docs/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribute
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

None

## Further comments
