### PR TITLE
Update chaindata link and add commands for rocky linux

### DIFF
--- a/docs/misc/operation/chaindata-snapshot.md
+++ b/docs/misc/operation/chaindata-snapshot.md
@@ -39,11 +39,11 @@ Download a compressed file to the new directory. URLs can be found at the bottom
 
 - Option 1. curl
   ```sh
-  curl -O https://s3.ap-northeast-2.amazonaws.com/klaytn-chaindata/mainnet/kaia-mainnet-chaindata-xxxxxxxxxxxxxx.tar.gz
+  curl -O https://storage.googleapis.com/kaia-chaindata/mainnet/kaia-mainnet-chaindata-xxxxxxxxxxxxxx.tar.gz
   ```
 - Option 2. wget
   ```sh
-  wget https://s3.ap-northeast-2.amazonaws.com/klaytn-chaindata/mainnet/kaia-mainnet-chaindata-xxxxxxxxxxxxxx.tar.gz
+  wget https://storage.googleapis.com/kaia-chaindata/mainnet/kaia-mainnet-chaindata-xxxxxxxxxxxxxx.tar.gz
   ```
 - Option 3. axel
   ```sh
@@ -52,7 +52,15 @@ Download a compressed file to the new directory. URLs can be found at the bottom
   sudo yum install axel pigz
 
   # Multi-threaded download and print status bar
-  axel -n8 https://s3.ap-northeast-2.amazonaws.com/klaytn-chaindata/mainnet/kaia-mainnet-chaindata-xxxxxxxxxxxxxx.tar.gz | awk -W interactive '$0~/\[/{printf "%s'$'\r''", $0}'
+  axel -n8 https://storage.googleapis.com/kaia-chaindata/mainnet/kaia-mainnet-chaindata-xxxxxxxxxxxxxx.tar.gz | awk -W interactive '$0~/\[/{printf "%s'$'\r''", $0}'
+  ```
+- Option 4. aria2
+  ```sh
+  # Rocky Linux installation example
+  sudo yum install epel-release aria2
+
+  # Lightweight, multi-connection download
+  aria2c https://storage.googleapis.com/kaia-chaindata/mainnet/kaia-mainnet-chaindata-xxxxxxxxxxxxxx.tar.gz
   ```
 
 ## Decompress the File
@@ -63,7 +71,7 @@ Download a compressed file to the new directory. URLs can be found at the bottom
   ```
 - Option 2. tar and pigz
   ```sh
-  # Amazon Linux installation example
+  # Amazon Linux & Rocky Linux installation example
   sudo yum install pigz
 
   # Multi-threaded decompression


### PR DESCRIPTION
## Proposed changes

- This PR updates sample output that includes old download links for chaindata
- Also, add Rocky Linux example (`axel` not available in Rocky Linux, use `aria2` instead)

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Minor Issues and Typos
- [x] Major Content Contribution
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to reach out. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia-docs/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribute
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

None

## Further comments

None