### PR TITLE
Fix unintended appearance of rating button

### DIFF
--- a/src/theme/Footer/Rating/Rating.js
+++ b/src/theme/Footer/Rating/Rating.js
@@ -26,7 +26,9 @@ export default function FeelbackRating() {
   const containerRef = useRef(null);
 
   useEffect(() => {
-    if (typeof window === 'undefined' || location.pathname === '/') {
+    // Uses a regex pattern to detect both root ('/') and localized ('/zh-CN/', '/vi/', etc.) homepages 
+    const isHomePage = location.pathname === '/' || /^\/([\w-]+)?\/$/.test(location.pathname);
+    if (typeof window === 'undefined' || isHomePage) {
       return;
     }
 


### PR DESCRIPTION
## Proposed changes

Prevent the up/down rating button from appearing on the homepage of non-English languages.
![image](https://github.com/user-attachments/assets/c1e8974b-07cc-499f-8d72-7d4443ae4733)


## Types of changes

Please put an x in the boxes related to your change.

- [ ] Minor Issues and Typos
- [ ] Major Content Contribution
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to reach out. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia-docs/blob/main/CONTRIBUTING.md)
- [x] I have read the [CLA](https://gist.github.com/kaiachain-dev/bbf65cc330275c057463c4c94ce787a6) and signed by comment ```I have read the CLA Document and I hereby sign the CLA``` in first time contribute
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues


## Further comments

