### PR TITLE
fix: update broken links kaia-contracts-wizard.md

### DIFF
--- a/i18n/vi/docusaurus-plugin-content-docs/current/build/tools/kaia-contracts-wizard.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/build/tools/kaia-contracts-wizard.md
@@ -291,7 +291,7 @@ In this section we will go through deploying our generated smart contract code u
 
 ### Getting Started
 
-While getting started with foundry, you must have been exposed to the preliminary way of delaying contracts using [forge create](https://book.getfoundry.sh/reference/forge/forge-create.html). Recently, the Foundry team came up with a more user friendly way of declaratively deploying contracts using Solidity called [Solidity Scripting](https://book.getfoundry.sh/tutorials/solidity-scripting#solidity-scripting) i.e writing deployment scripts in solidity instead of JavaScript.
+While getting started with foundry, you must have been exposed to the preliminary way of delaying contracts using [forge create](https://book.getfoundry.sh/reference/forge/forge-create.html). Recently, the Foundry team came up with a more user friendly way of declaratively deploying contracts using Solidity called [Solidity Scripting](https://book.getfoundry.sh/guides/scripting-with-solidity#scripting-with-solidity) i.e writing deployment scripts in solidity instead of JavaScript.
 
 In this section, we will deploy our contract using solidity scripting in Foundry.
 
@@ -415,7 +415,7 @@ Subsequently, we called the **vm.startBroadcast(deployerPrivateKey)** special ch
 
 We then created the respective contract. This contract creation will be recorded by forge because we previously called the vm.startBroadcast() cheat code.
 
-Now that we have gotten an overview of what each line entails, you can move on to deploy the contracts.  Click this [link](https://book.getfoundry.sh/tutorials/solidity-scripting#writing-the-script), to learn more about writing scripts and other details.
+Now that we have gotten an overview of what each line entails, you can move on to deploy the contracts.  Click this [link](https://book.getfoundry.sh/guides/scripting-with-solidity#writing-the-script), to learn more about writing scripts and other details.
 
 At the root of the project run
 


### PR DESCRIPTION
## ✨ Proposed Changes
Hi! I fixes broken links in the `kaia-contracts-wizard.md` file. The old links pointed to the deprecated Foundry documentation pages for Solidity scripting (`tutorials/solidity-scripting`). They have been updated to the correct and current links: `guides/scripting-with-solidity`.

- Replaced `https://book.getfoundry.sh/tutorials/solidity-scripting` with `https://book.getfoundry.sh/guides/scripting-with-solidity`.
- Replaced `https://book.getfoundry.sh/tutorials/solidity-scripting#writing-the-script` with `https://book.getfoundry.sh/guides/scripting-with-solidity#writing-the-script`.

## 🗂️ Types of changes

<!-- Please put an x in the boxes related to your change (i.e. [x]).-->

- [x] Minor Issues and Typos
- [ ] Major Content Contribution
- [ ] Others (e.g. platform-specific changes)


## ✅ Checklist

<!-- Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to reach out. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia-docs/blob/main/CONTRIBUTING.md).
- [ ] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.