### PR TITLE
docs: fix grammar in "Contributing Translations" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Before submitting PRs, make sure to:
 
 ### Contributing Translations
 
-Kaia docs is available in the following languages:
+Kaia docs are available in the following languages:
 
 - English
 - 한국어


### PR DESCRIPTION
## ✨ Proposed Changes

Noticed a grammatical mistake in the **Contributing Translations** section.  

Changed **"Kaia docs is available in the following languages:"** → **"Kaia Docs are available in the following languages:"** to properly agree with "Docs" as a plural noun.

## 🗂️ Types of changes

- [x] Minor Issues and Typos
- [ ] Major Content Contribution
- [ ] Others (e.g. platform-specific changes)

## ✅ Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia-docs/blob/main/CONTRIBUTING.md).
- [ ] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.
