### PR TITLE
fix: fix incorrect regex in titleRegex

### DIFF
--- a/web3rpc/delete-endpoint.js
+++ b/web3rpc/delete-endpoint.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const endpointRegex = /<MethodEndpoint(.*?)MethodEndpoint>/s;
-const titleRegex = /sidebar_label: "\[[a-zA-Z]+\]/s;
+const titleRegex = /sidebar_label: "\[[a-zA-Z]+\]"/s;
 
 const deleteEndpoint = (path) => {
     fs.readdir(path, (err, files) => {


### PR DESCRIPTION
## ✨ Proposed Changes  
I noticed a issue in the `titleRegex` pattern—there was an unclosed quotation mark before `\[` that could cause the regex to fail. If the quotes are needed, they should be properly closed.  

Fixed it by updating the pattern to:  
```js
const titleRegex = /sidebar_label: "\[[a-zA-Z]+\]"/s;
```  
Now, it correctly captures the expected format. Let me know if any adjustments are needed!  

## 🗂️ Types of changes  
- [x] Minor Issues and Typos  
- [ ] Major Content Contribution  
- [ ] Others (e.g. platform-specific changes)  

## ✅ Checklist  
- [x] I have read the [[CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia-docs/blob/main/CONTRIBUTING.md)](https://github.com/kaiachain/kaia-docs/blob/main/CONTRIBUTING.md).  
- [x] I have added necessary documentation (if appropriate).  
- [x] Any dependent changes have been merged and published in downstream modules.  

## 📌 Related issues  
_No related issues._  

## 💡 Further comments  
_No further comments._