### PR TITLE
Add Vale linter for style checking

### DIFF
--- a/.github/styles/config/vocabularies/kaia-docs/accept.txt
+++ b/.github/styles/config/vocabularies/kaia-docs/accept.txt
@@ -1,0 +1,2 @@
+Kaia
+Crowdin

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -1,0 +1,22 @@
+name: Vale Linting
+on: [pull_request]
+jobs:
+  vale:
+    name: Writing Checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Vale Check
+        uses: errata-ai/vale-action@v2.1.1
+        with:
+          files: docs
+          # added, diff_context, file, nofilter
+          filter_mode: added
+          # github-pr-check, github-pr-review, github-check
+          reporter: github-pr-review
+          vale_flags: --glob=*.{md} --minAlertLevel=error
+          fail_on_error: false
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,16 @@
+StylesPath = .github/styles
+MinAlertLevel = suggestion
+Vocab = kaia-docs
+Packages = Google, proselint, MDX
+
+[*.{md}]
+# ^ This section applies to only Markdown files.
+#
+# You can change (or add) file extensions here
+# to apply these settings to other file types.
+#
+# For example, to apply these settings to both
+# Markdown and reStructuredText:
+#
+# [*.{md,rst}]
+BasedOnStyles = Vale, Google, proselint


### PR DESCRIPTION
## ✨ Proposed Changes

<!-- Describe your changes to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.-->

- Add [Vale linter](https://vale.sh/) for automatic style checking to enforce consistent writing standards across all documentation. It will [run on every PR](https://github.com/errata-ai/vale-action) and provide suggestions, warnings and error based on pre-defined style rules
  - Google Developer Documentation Style Guide and Proslint style integrated
  - Kaia-specific rules to be added

## 🗂️ Types of changes

<!-- Please put an x in the boxes related to your change (i.e. [x]).-->

- [ ] Minor Issues and Typos
- [ ] Major Content Contribution
- [x] Others (e.g. platform-specific changes)

## ✅ Checklist

<!-- Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to reach out. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia-docs/blob/main/CONTRIBUTING.md).
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## 📌 Related issues

<!-- Please leave the issue numbers or links related to this PR here something like `Fixes #1234` or `Related to #1234`. -->


## 💡 Further comments

<!-- If this is a relatively large content contribution, kick off the discussion by explaining why you would suggest the content contribution, etc... -->