### PR TITLE
docs: Fix typo in error code

### DIFF
--- a/docs/learn/accounts.md
+++ b/docs/learn/accounts.md
@@ -165,7 +165,7 @@ If an account has the key AccountKeyFail, the transaction validation process alw
 
 | Attribute | Type | Description |
 | :--- | :--- | :--- |
-| Type | uint8 \(Go\) | The type of AcccountKeyFail. It must be **0x03**. |
+| Type | uint8 \(Go\) | The type of AccountKeyFail. It must be **0x03**. |
 
 #### RLP Encoding <a id="rlp-encoding"></a>
 


### PR DESCRIPTION
## ✨ Proposed Changes

Noticed a small typo in the error code—an extra "c" in "AcccountKeyFail." Fixed it to "AccountKeyFail" for consistency. 

## 🗂️ Types of changes

- [x] Minor Issues and Typos
- [ ] Major Content Contribution
- [ ] Others (e.g. platform-specific changes)

## 🔒 CLA requirements - FIRST-TIME CONTRIBUTORS only 📝

**Welcome!** Before we can review your PR, there's one important step:

1. **Read** our [Contributor License Agreement](https://github.com/kaiachain/kaia-docs/blob/main/.github/CLA.md).
2. **Sign** by commenting **exactly** this in the PR: ```I have read the CLA Document and I hereby sign the CLA```

🔍 **Why This Matters:** This protects both you and the project, ensuring everyone can safely use your contributions. Without CLA signing, we can't merge your PR. Thank you for your understanding!

## ✅ Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia-docs/blob/main/CONTRIBUTING.md).
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## 📌 Related issues


## 💡 Further comments