### PR TITLE
chore: Fix crash on missing directory & sidebar_label replacement

### DIFF
--- a/web3rpc/delete-endpoint.js
+++ b/web3rpc/delete-endpoint.js
@@ -4,27 +4,34 @@ const titleRegex = /sidebar_label: "\[[a-zA-Z]+\]"/s;
 
 const deleteEndpoint = (path) => {
     fs.readdir(path, (err, files) => {
+        if (err) {
+            console.error(`Error reading directory ${path}:`, err);
+            return;
+        }
+
         files.forEach(file => {
             // Read the file contents
             let fileContents = fs.readFileSync(path + "/" + file, 'utf8');
             
             // Replace the matching text
-            let newFileContents = fileContents.replace(endpointRegex, '').replace(titleRegex, "sidebar_label: \"");
-            
+            let newFileContents = fileContents
+                .replace(endpointRegex, '')
+                .replace(titleRegex, 'sidebar_label: ""');
+
             // Write the updated contents back to the file
             fs.writeFileSync(path + "/" + file, newFileContents);
-        })
-    })
+        });
+    });
 }
 
-deleteEndpoint('../docs/references/json-rpc/klay')
-deleteEndpoint('../docs/references/json-rpc/kaia')
-deleteEndpoint('../docs/references/json-rpc/eth')
-deleteEndpoint('../docs/references/json-rpc/debug')
-deleteEndpoint('../docs/references/json-rpc/admin')
-deleteEndpoint('../docs/references/json-rpc/governance')
-deleteEndpoint('../docs/references/json-rpc/net')
-deleteEndpoint('../docs/references/json-rpc/txpool')
-deleteEndpoint('../docs/references/json-rpc/mainbridge')
-deleteEndpoint('../docs/references/json-rpc/subbridge')
-deleteEndpoint('../docs/references/json-rpc/personal')
+deleteEndpoint('../docs/references/json-rpc/klay');
+deleteEndpoint('../docs/references/json-rpc/kaia');
+deleteEndpoint('../docs/references/json-rpc/eth');
+deleteEndpoint('../docs/references/json-rpc/debug');
+deleteEndpoint('../docs/references/json-rpc/admin');
+deleteEndpoint('../docs/references/json-rpc/governance');
+deleteEndpoint('../docs/references/json-rpc/net');
+deleteEndpoint('../docs/references/json-rpc/txpool');
+deleteEndpoint('../docs/references/json-rpc/mainbridge');
+deleteEndpoint('../docs/references/json-rpc/subbridge');
+deleteEndpoint('../docs/references/json-rpc/personal');


### PR DESCRIPTION
## ✨ Proposed Changes

- Fixed a crash when the directory is missing by adding proper error handling in `fs.readdir`.  
- Corrected `sidebar_label` replacement to prevent formatting issues.  
- Improved readability by formatting `replace()` calls on separate lines.  

## 🗂️ Types of changes

- [x] Minor Issues and Typos  
- [ ] Major Content Contribution  
- [ ] Others (e.g. platform-specific changes)  

## 🔒 CLA requirements - FIRST-TIME CONTRIBUTORS only 📝

I have read the CLA Document and I hereby sign the CLA

## ✅ Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia-docs/blob/main/CONTRIBUTING.md).  
- [ ] I have added necessary documentation (if appropriate).  
- [ ] Any dependent changes have been merged and published in downstream modules.  

## 📌 Related issues

N/A  

## 💡 Further comments

Now the script handles missing directories gracefully and ensures `sidebar_label` is correctly formatted. 🚀  