### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get AWS credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
Maintenance update to actions/checkout@v4 to align with the current runner stack; nothing else modified.