### PR TITLE
Update Vale linter's spell checking configuration

### DIFF
--- a/.github/workflows/branch-check.yml
+++ b/.github/workflows/branch-check.yml
@@ -19,13 +19,6 @@ jobs:
         with:
           message: |
             Pls create PR to branch `main`
-      - name: Comment Success
-        if: (github.event_name == 'pull_request_target' || github.event.pull_request == 'edited' ) && github.base_ref == 'main'
-        uses: thollander/actions-comment-pull-request@v3
-        id: success
-        with:
-          message: |
-            Passed branch check
       - name: "Branch check Assistant"
         if: github.event_name == 'pull_request_target' || github.event.pull_request == 'edited'
         shell: bash

--- a/.vale.ini
+++ b/.vale.ini
@@ -18,3 +18,9 @@ BasedOnStyles = Vale, Google, proselint, kaia-docs
 # Override the Google.Spacing rule
 Google.Spacing = NO
 kaia-docs.CustomSpacing = YES
+
+# Ignore fenced code blocks (``` and ~~~)
+BlockIgnores = (?s)```.*?```, (?s)~~~.*?~~~
+
+# Ignore inline code `likeThis()`
+TokenIgnores = `[^`]+`


### PR DESCRIPTION
## ✨ Proposed Changes

<!--
**REQUIRED:** Describe your changes clearly.
- What problem does this solve or what goal does it achieve?
- What are the key changes made?
- What is the rationale behind these changes?

**If you are a maintainer/regular contributor submitting without a prior issue, provide detailed context here.**
-->

- Configure Vale linter to suppress false-positive spelling errors by ignoring spell checking for code blocks
- Update the branch check workflow that it comments only when the base branch isn’t `main`

## 🗂️ Types of changes

<!-- Please put an x in the boxes related to your change (i.e. [x]).-->

- [ ] Minor Issues and Typos
- [ ] Major Content Contribution
- [x] Others (e.g. platform-specific changes)

## ✅ Checklist

<!-- Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to reach out. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia-docs/blob/main/CONTRIBUTING.md).
- [ ] **If following Standard Workflow:** I have linked the approved issue below.
- [x] **If submitting without a prior issue (Maintainer/Regular):** I have provided detailed context in the "Proposed Changes" section above.
- [ ] My changes render correctly (if applicable, run `npm run build` locally).
- [ ] I have added necessary documentation updates (if appropriate).
- [ ] Any dependent changes have been merged and published.

## 📌 Related issues
<!--
- **Required** if you checked "Content Contribution / Other Change (Standard Workflow)". Link the approved issue (e.g., `Fixes #123` or `Related to #1234`).
- **Optional** (but encouraged for large changes) if submitted by a Maintainer/Regular Contributor without a prior issue.
- Leave blank or write "N/A" for Minor Fixes.
-->

## 💡 Further comments

<!-- Add any other context, screenshots, or information here. -->