### PR TITLE
docs: improve local development guide for i18n testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,19 +48,51 @@ $ npm i
 
 ### Local Development
 
+#### Running in Development Mode
+By default, the development server runs with English locale only:
 ```
 $ npm start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
 
-### Build
+> [!NOTE]
+> In development mode (`npm start`), only one language is loaded at a time, so the language switcher in the UI will not work.
 
+#### Developing with Other Languages
+
+To develop with a specific language:
+```
+# Korean
+$ npm start -- --locale ko
+
+# Japanese  
+$ npm start -- --locale ja
+
+# Simplified Chinese
+$ npm start -- --locale zh-CN
+
+# Traditional Chinese
+$ npm start -- --locale zh-TW
+
+# Vietnamese
+$ npm start -- --locale vi
+```
+
+### Build
 ```
 $ npm run build
 ```
-
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
+
+#### Testing All Languages
+To test the language switcher functionality (as it works on the live site), you need to build and serve the production version:
+```
+$ npm run build
+$ npm run serve
+```
+Then visit http://localhost:3000 and the language dropdown will work correctly with all available languages.
+
 
 ### Deployment
 


### PR DESCRIPTION
Improves the Local Development section in README to clarify i18n behavior during local development.

## ✨ Proposed Changes

<!--
**REQUIRED:** Describe your changes clearly.
- What problem does this solve or what goal does it achieve?
- What are the key changes made?
- What is the rationale behind these changes?

**If you are a maintainer/regular contributor submitting without a prior issue, provide detailed context here.**
-->

### Problem
When following the current README instructions (`npm start`), developers may be confused why:
1. The language switcher appears in the UI but doesn't work
2. Only English content is shown despite multiple languages being configured
3. The local behavior differs from the production site (https://docs.kaia.io)

This creates confusion as it appears the site is broken, when in fact this is expected Docusaurus behavior.

### Changes Made
- Added explanation that development mode loads only one locale at a time
- Added commands for developing with specific languages (Korean, Japanese, etc.)
- Added clear instructions for testing language switching using production build
- Clarified the difference between development and production behavior

### Testing
Verified that:
-  `npm start` runs English version (default)
-  `npm start -- --locale ko` runs Korean version
-  `npm run build && npm run serve` enables full language switching
-  All instructions in the updated README work correctly

### Rationale
This addresses a common point of confusion for new contributors and aligns with Docusaurus best practices for i18n development.

## 🗂️ Types of changes

<!-- Please put an x in the boxes related to your change (i.e. [x]).-->

- [X] Minor Issues and Typos
- [ ] Major Content Contribution
- [ ] Others (e.g. platform-specific changes)

## 🔒 CLA requirements - FIRST-TIME CONTRIBUTORS only 📝

**Welcome!** Before we can review your PR, there's one important step:

1. **Read** our [Contributor License Agreement](https://github.com/kaiachain/kaia-docs/blob/main/.github/CLA.md).
2. **Sign** by commenting **exactly** this in the PR: ```I have read the CLA Document and I hereby sign the CLA```

🔍 **Why This Matters:** This protects both you and the project, ensuring everyone can safely use your contributions. Without CLA signing, we can't merge your PR. Thank you for your understanding!


## ✅ Checklist

<!-- Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to reach out. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [X] I have read the [CONTRIBUTING GUIDELINES](https://github.com/kaiachain/kaia-docs/blob/main/CONTRIBUTING.md).
- [ ] **If following Standard Workflow:** I have linked the approved issue below.
- [X] **If submitting without a prior issue (Maintainer/Regular):** I have provided detailed context in the "Proposed Changes" section above.
- [X] My changes render correctly (if applicable, run `npm run build` locally).
- [ ] I have added necessary documentation updates (if appropriate).
- [X] Any dependent changes have been merged and published.

## 📌 Related issues
<!--
- **Required** if you checked "Content Contribution / Other Change (Standard Workflow)". Link the approved issue (e.g., `Fixes #123` or `Related to #1234`).
- **Optional** (but encouraged for large changes) if submitted by a Maintainer/Regular Contributor without a prior issue.
- Leave blank or write "N/A" for Minor Fixes.
--> N/A - Minor documentation improvement

## 💡 Further comments

<!-- Add any other context, screenshots, or information here. --> This is my first contribution to Kaia Docs. I discovered this issue while setting up the local development environment and wanted to help prevent confusion for future contributors. Thank you for reviewing! 