### PR TITLE
Add Envio to indexers

### DIFF
--- a/docs/build/tools/indexers/indexers.md
+++ b/docs/build/tools/indexers/indexers.md
@@ -5,6 +5,7 @@ Blockchain indexers are tools used in the context of blockchain technology to im
 The following providers have integrated with Kaia to deliver blockchain indexing services:
 
 * [Envio](https://envio.dev/?utm_source=kaia&utm_medium=partner-docs)
+  * [Benchmarks](https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=kaia&utm_medium=partner-docs) - see Envio's indexing performance
 * [The Graph](https://thegraph.com/)
 * [SubQuery Network](https://academy.subquery.network/)
 

--- a/docs/build/tools/indexers/indexers.md
+++ b/docs/build/tools/indexers/indexers.md
@@ -5,7 +5,5 @@ Blockchain indexers are tools used in the context of blockchain technology to im
 The following providers have integrated with Kaia to deliver blockchain indexing services:
 
 * [Envio](https://envio.dev/?utm_source=kaia&utm_medium=partner-docs)
-  * [Benchmarks](https://docs.envio.dev/docs/HyperIndex/benchmarking?utm_source=kaia&utm_medium=partner-docs) - see Envio's indexing performance
 * [The Graph](https://thegraph.com/)
 * [SubQuery Network](https://academy.subquery.network/)
-

--- a/docs/build/tools/indexers/indexers.md
+++ b/docs/build/tools/indexers/indexers.md
@@ -4,5 +4,7 @@ Blockchain indexers are tools used in the context of blockchain technology to im
 
 The following providers have integrated with Kaia to deliver blockchain indexing services:
 
+* [Envio](https://envio.dev/?utm_source=kaia&utm_medium=partner-docs)
 * [The Graph](https://thegraph.com/)
 * [SubQuery Network](https://academy.subquery.network/)
+


### PR DESCRIPTION
This adds Envio to the indexers provider list.

Envio is a high-performance indexing framework that turns smart contract events into a queryable GraphQL API. Its HyperIndex framework supports indexing any EVM chain out of the box, including Kaia, using your own RPC as the data source, with fully managed hosting on Envio Cloud or self-hosting. The entry mirrors the existing list format.

Links:
- Website: https://envio.dev/
- Docs: https://docs.envio.dev/
