### PR TITLE
ci: serialize prod deployments with concurrency group

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -4,6 +4,15 @@ on:
     branches:
       - main
 
+# Serialize prod deployments: concurrent runs race on `aws s3 sync --delete`
+# against the same bucket and can leave it in a mixed state (see the Jul 2026
+# empty-pages incident). cancel-in-progress must stay false — cancelling a run
+# mid-sync would leave a partial deployment. GitHub keeps at most one pending
+# run queued, so rapid consecutive merges collapse into a single trailing deploy.
+concurrency:
+  group: prod-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy:
     name: deploy


### PR DESCRIPTION
## Why

On Jul 20, PRs #414 / #429 / #430 merged within 46 seconds, triggering **three prod deploy runs that executed concurrently**. Each run performs `aws s3 sync ./build/ $S3_BUCKET_PROD --delete`, so the racing syncs deleted each other's content-hashed assets. The bucket was left in a mixed state — HTML from one build referencing JS chunks deleted by another — which caused the empty pages observed on docs.kaia.io (Jul 22), recovered by re-running #431's deploy.

Incident summary: https://kaia-foundation.atlassian.net/wiki/x/HgApIg

## What

Add a `concurrency` group to `prod.yml` so prod deploys are serialized:

- Only one deploy runs at a time; new pushes queue behind it.
- `cancel-in-progress: false` on purpose — cancelling a run mid-`s3 sync` would leave a partial deployment (the same class of corruption as the incident).
- GitHub keeps at most one pending run in the queue, so rapid consecutive merges collapse into a single trailing deploy of the newest commit.

## Note

The invalid-redirect build failure introduced in #432 has been fixed by #433, so `main` builds again and merging this PR is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)