### PR TITLE
fix: remove duplicate kaia-safe redirects that break the prod build

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -59,11 +59,12 @@ const redirects = [
   { from: '/build/get-started/before-you-start', to: '/build/get-started/foundation-setup' },
   { from: '/learn/storage/state-pruning', to: '/learn/storage/storage-optimization' },
   // Safe Wallet rename (kaia-safe → safe-wallet) — renamed page slugs
+  // Note: '/build/wallets/kaia-safe' and '/build/tools/wallets/kaia-safe' are
+  // intentionally NOT listed here — folderRedirects below already generates
+  // those redirects, and duplicating them fails the build (EEXIST on index.html).
   {
     from: [
-      '/build/wallets/kaia-safe',
       '/build/wallets/kaia-safe/kaia-safe',
-      '/build/tools/wallets/kaia-safe',
       '/build/tools/wallets/kaia-safe/kaia-safe',
     ],
     to: '/build/wallets/safe-wallet',


### PR DESCRIPTION
## Why

The prod deploy for #433 ([run 30067546387](https://github.com/kaiachain/kaia-docs/actions/runs/30067546387)) failed at **Build static files**:

```
[ERROR] Redirect file creation error for ".../build/build/wallets/kaia-safe/index.html".
[cause]: EEXIST: file already exists
```

After #433 changed the redirect target to `/build/wallets/safe-wallet`, **two sources now generate the same redirects**:

1. The explicit entry in `redirects` with `from: ['/build/wallets/kaia-safe', '/build/tools/wallets/kaia-safe', ...]`
2. `createRedirects` via `folderRedirects` (`['/build/wallets/kaia-safe', '/build/wallets/safe-wallet']` etc.), which generates the same two folder-level paths for the `/build/wallets/safe-wallet/` category-index route

The redirect plugin writes `index.html` for the first one, then hits `EEXIST` on the second → build fails.

## What

Remove the two folder-level paths from the explicit entry, keeping only the page-slug forms (`…/kaia-safe/kaia-safe`) that `folderRedirects` does not cover. Net redirect coverage is unchanged.

## Verification

- Simulated the plugin's from-path generation over all 886 doc routes (explicit `redirects` + `createRedirects`): **0 duplicates after this fix**; the pre-fix `main` reproduces exactly the 2 duplicates (`/build/wallets/kaia-safe`, `/build/tools/wallets/kaia-safe`) matching the run failure.
- Full local prod build (`generate-docs.sh` + `web3rpc.sh` + `npm run build`) in progress; will confirm in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)